### PR TITLE
fix(security): basic-auth gate on /argue/log admin route

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -28,7 +28,78 @@ if you have a name and a working memory, you are welcome at bines.ai/argue like 
 — maria
 `;
 
+const ADMIN_REALM = 'bines.ai admin';
+
+/**
+ * Constant-time string compare. Edge runtime has no Node `crypto.timingSafeEqual`,
+ * so this is a hand-rolled equivalent. Length-and-content compare without
+ * early-out — the password length is documented as ASCII to keep
+ * `charCodeAt` exact.
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+function unauthorized(): NextResponse {
+  return new NextResponse('authentication required', {
+    status: 401,
+    headers: {
+      'WWW-Authenticate': `Basic realm="${ADMIN_REALM}"`,
+      'Content-Type': 'text/plain; charset=utf-8',
+      'X-Governed-By': 'bines.ai',
+      'X-Robots-Tag': 'noindex, nofollow',
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+/**
+ * HTTP Basic Auth gate for /argue/log. Reads `ARGUE_LOG_PASSWORD` from
+ * the environment; fail-closed (503) if unconfigured. Username is ignored
+ * — the password alone is the secret. Returns null when the request is
+ * authorised; returns a 401 response otherwise.
+ */
+function checkAdminAuth(req: NextRequest): NextResponse | null {
+  const expected = process.env.ARGUE_LOG_PASSWORD;
+  if (!expected) {
+    return new NextResponse('admin route is not configured', {
+      status: 503,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'X-Governed-By': 'bines.ai',
+        'Cache-Control': 'no-store',
+      },
+    });
+  }
+  const header = req.headers.get('authorization') ?? '';
+  const prefix = 'Basic ';
+  if (!header.startsWith(prefix)) return unauthorized();
+  let decoded: string;
+  try {
+    decoded = atob(header.slice(prefix.length));
+  } catch {
+    return unauthorized();
+  }
+  const colonIndex = decoded.indexOf(':');
+  const password = colonIndex < 0 ? decoded : decoded.slice(colonIndex + 1);
+  if (!timingSafeEqual(password, expected)) return unauthorized();
+  return null;
+}
+
 export function middleware(req: NextRequest): NextResponse {
+  const path = req.nextUrl.pathname;
+
+  // /argue/log and any sub-path is admin-only — basic auth gate.
+  if (path === '/argue/log' || path.startsWith('/argue/log/')) {
+    const denied = checkAdminAuth(req);
+    if (denied) return denied;
+  }
+
   const ua = (req.headers.get('user-agent') ?? '').toLowerCase();
   if (ua && BLOCKED_BOT_UA.some((needle) => ua.includes(needle))) {
     return new NextResponse(SNARK, {


### PR DESCRIPTION
## Summary

Hotfix — production /argue/log was returning the admin page directly (200 with full content), since Vercel Deployment Protection toggles all-or-nothing per environment and would auth-wall the entire public site if used.

Adds HTTP Basic Auth at the middleware level on `/argue/log` and any sub-path. Reads `ARGUE_LOG_PASSWORD` from env (fail-closed 503 if unconfigured), accepts any username, checks the password via timing-safe compare. Returns 401 + `WWW-Authenticate: Basic` so browsers pop a native login dialog.

Mitigating note: production has zero argue-log entries right now (deploy is brand new), so nothing was actually exposed visitor-facing — but this needs to ship before anyone uses `/argue` and creates log entries.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` (556 passed), `pnpm build` — all green on dev
- [x] `ARGUE_LOG_PASSWORD` set on Vercel production via CLI (not committed)
- [ ] Post-merge: hit `/argue/log` on the production deployment URL — browser should pop a basic-auth dialog. Correct password gets in. Anything else returns 401.
- [ ] Public surfaces (`/`, `/fieldwork`, `/postcards`, `/argue`, `/about`, `/privacy`, etc.) remain unauthenticated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)