### PR TITLE
fix(footer): hard nav on About/Privacy/Argue footer links

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,10 +1,16 @@
-import Link from 'next/link';
-
 /**
  * Site footer — rendered beneath the AntipatternsStrip in PageShell.
  * Three things: dynamic copyright (so the year never goes stale), a small
  * link row to /about + /privacy + /argue, and a quiet "my own work, mostly"
  * tag that callbacks the /now closer.
+ *
+ * Footer links use plain <a> rather than next/link by design. PageShell is
+ * a shared async server layout, and a Link click from the very bottom of a
+ * long page leaves scroll parked at the footer — visually the page looks
+ * unchanged even though routing succeeded. Hard navigation guarantees the
+ * scroll reset to top, and these are low-traffic terminal pages where the
+ * full reload cost is negligible. /argue benefits in particular: a fresh
+ * load clears any prior chat state.
  *
  * The copyright year is computed at SERVER render time (this is an RSC).
  * On Vercel the year flips automatically at the New Year UTC boundary on
@@ -12,6 +18,7 @@ import Link from 'next/link';
  */
 export function Footer() {
   const year = new Date().getFullYear();
+  const linkClass = 'hover:text-ink transition-colors motion-reduce:transition-none';
 
   return (
     <div className="mt-10 pt-6 border-t border-ink/10 font-mono text-xs text-ink/55 flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
@@ -23,25 +30,19 @@ export function Footer() {
       <nav aria-label="Footer">
         <ul className="flex flex-wrap gap-x-4 gap-y-2 uppercase tracking-[0.14em]">
           <li>
-            <Link href="/about" className="hover:text-ink transition-colors motion-reduce:transition-none">
+            <a href="/about" className={linkClass}>
               about
-            </Link>
+            </a>
           </li>
           <li>
-            <Link
-              href="/privacy"
-              className="hover:text-ink transition-colors motion-reduce:transition-none"
-            >
+            <a href="/privacy" className={linkClass}>
               privacy
-            </Link>
+            </a>
           </li>
           <li>
-            <Link
-              href="/argue"
-              className="hover:text-ink transition-colors motion-reduce:transition-none"
-            >
+            <a href="/argue" className={linkClass}>
               argue
-            </Link>
+            </a>
           </li>
         </ul>
       </nav>


### PR DESCRIPTION
## Summary

Footer Links via next/link were doing client-side soft nav from the very bottom of long pages. Routing succeeded, but the shared async PageShell left scroll parked at the footer — visually the page looked unchanged. Switching the three footer links to plain `<a>` forces hard navigation: scroll resets to top, URL flips, page paints fresh.

/argue benefits specifically — a fresh load clears any prior chat state and resets prefill.

Header `<Nav>` keeps using `<Link>` (those are mid-page navigations where soft nav is the right call).

## Test plan

- [ ] Click About from a Fieldwork piece → /about page visible at top of viewport
- [ ] Click Privacy from a Fieldwork piece → /privacy page visible at top
- [ ] Click Argue from a Fieldwork piece → /argue page with empty input
- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)