### PR TITLE
fix(now): add byline under Now heading

### DIFF
--- a/src/components/NowBlock.tsx
+++ b/src/components/NowBlock.tsx
@@ -17,8 +17,11 @@ export function NowBlock({ now }: NowBlockProps) {
       style={{ ['--color-accent' as string]: accentVar(accent) } as React.CSSProperties}
     >
       <header className="mb-10">
-        <h1 className="font-serif font-black text-5xl tracking-tight mb-4">Now</h1>
-        <p className="font-mono text-xs uppercase tracking-[0.14em] text-ink/60">
+        <h1 className="font-serif font-black text-5xl tracking-tight mb-3">Now</h1>
+        <p className="font-serif text-base text-ink/70 italic">
+          The longer version of the line that runs at the top of every page. Edited monthly.
+        </p>
+        <p className="mt-3 font-mono text-xs uppercase tracking-[0.14em] text-ink/60">
           last updated <time dateTime={updated}>{fmtDate(updated)}</time>
         </p>
       </header>


### PR DESCRIPTION
## Summary

The /now page jumped straight from heading to last-updated date with no explanation of what Now is. Adds a one-line italic byline matching the pattern on /fieldwork, /postcards, /changed-my-mind:

> *The longer version of the line that runs at the top of every page. Edited monthly.*

Anchors the page to the strip line readers see at the top of every page, and explains the cadence.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm build` clean
- [ ] Visit /now on the preview — byline visible under "Now" heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)