### PR TITLE
fix(metadata): drop third bines.ai from og:title

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,7 @@ const SITE_URL = 'https://bines.ai';
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: {
-    default: 'bines.ai',
+    default: 'Maria Bines',
     template: '%s · bines.ai',
   },
   description:


### PR DESCRIPTION
## Summary

Brand already shows in the OG image wordmark and as the URL host beneath the card. Setting `og:title` to "bines.ai" was a third repetition. Default page title is now "Maria Bines"; subpage titles still get the `· bines.ai` template (e.g., "Fieldwork · bines.ai").

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm build` clean
- [ ] LinkedIn Post Inspector → Inspect on `https://bines.ai` → top of card reads "Maria Bines", host beneath reads "bines.ai"
- [ ] Subpage e.g. `/fieldwork` browser tab still reads "Fieldwork · bines.ai"

🤖 Generated with [Claude Code](https://claude.com/claude-code)