### PR TITLE
fix(blob): switch storage to private-access mode

### DIFF
--- a/src/lib/argue-judge/__tests__/storage.test.ts
+++ b/src/lib/argue-judge/__tests__/storage.test.ts
@@ -3,9 +3,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 vi.mock('@vercel/blob', () => ({
   list: vi.fn(),
   put: vi.fn(),
+  get: vi.fn(),
 }));
 
-import { list, put } from '@vercel/blob';
+import { list, put, get } from '@vercel/blob';
 import {
   appendArgueJudge,
   listArgueJudgeDays,
@@ -17,9 +18,21 @@ import type { ArgueJudgeVerdict } from '../schema';
 
 const listMock = vi.mocked(list);
 const putMock = vi.mocked(put);
+const getMock = vi.mocked(get);
 
 const ORIG_TOKEN = process.env.BLOB_READ_WRITE_TOKEN;
-const ORIG_FETCH = globalThis.fetch;
+
+function getOk(body: string) {
+  return {
+    statusCode: 200,
+    stream: new Response(body).body,
+    headers: {},
+    blob: {},
+  } as never;
+}
+function getMissing() {
+  return null as never;
+}
 
 function validVerdict(overrides: Partial<ArgueJudgeVerdict> = {}): ArgueJudgeVerdict {
   return {
@@ -78,13 +91,13 @@ function spyConsole(): {
 beforeEach(() => {
   listMock.mockReset();
   putMock.mockReset();
+  getMock.mockReset();
   process.env.BLOB_READ_WRITE_TOKEN = 'fake-token';
 });
 
 afterEach(() => {
   if (ORIG_TOKEN === undefined) delete process.env.BLOB_READ_WRITE_TOKEN;
   else process.env.BLOB_READ_WRITE_TOKEN = ORIG_TOKEN;
-  globalThis.fetch = ORIG_FETCH;
 });
 
 describe('appendArgueJudge', () => {
@@ -115,7 +128,7 @@ describe('appendArgueJudge', () => {
     expect(filename).toBe('argue-judges/2026-04-25.jsonl');
     expect(String(body).trim().split('\n')).toHaveLength(1);
     expect(opts).toMatchObject({
-      access: 'public',
+      access: 'private',
       contentType: 'application/x-ndjson',
       addRandomSuffix: false,
       allowOverwrite: true,
@@ -135,9 +148,7 @@ describe('appendArgueJudge', () => {
     const previousLine =
       JSON.stringify(validVerdict({ conversation_id: '22222222-2222-4222-8222-222222222222' })) +
       '\n';
-    globalThis.fetch = vi.fn(() =>
-      Promise.resolve(new Response(previousLine, { status: 200 })),
-    ) as unknown as typeof fetch;
+    getMock.mockResolvedValue(getOk(previousLine));
     putMock.mockResolvedValue(undefined as never);
 
     await appendArgueJudge(validVerdict(), {
@@ -218,9 +229,7 @@ describe('readArgueJudgeDay', () => {
       '\n' +
       JSON.stringify(validVerdict({ conversation_id: '22222222-2222-4222-8222-222222222222' })) +
       '\n';
-    globalThis.fetch = vi.fn(() =>
-      Promise.resolve(new Response(lines, { status: 200 })),
-    ) as unknown as typeof fetch;
+    getMock.mockResolvedValue(getOk(lines));
 
     const out = await readArgueJudgeDay('2026-04-25');
     expect(out).toHaveLength(2);
@@ -237,9 +246,7 @@ describe('readArgueJudgeDay', () => {
       'not-json-at-all\n' +
       JSON.stringify({ schema_version: 99, broken: true }) +
       '\n';
-    globalThis.fetch = vi.fn(() =>
-      Promise.resolve(new Response(text, { status: 200 })),
-    ) as unknown as typeof fetch;
+    getMock.mockResolvedValue(getOk(text));
 
     const out = await readArgueJudgeDay('2026-04-25');
     expect(out).toHaveLength(1);
@@ -282,10 +289,10 @@ describe('readAllArgueJudges', () => {
       JSON.stringify(validVerdict({ conversation_id: '33333333-3333-4333-8333-333333333333' })) +
       '\n';
     let n = 0;
-    globalThis.fetch = vi.fn(() => {
+    getMock.mockImplementation(async () => {
       const body = ++n === 1 ? day1 : day2;
-      return Promise.resolve(new Response(body, { status: 200 }));
-    }) as unknown as typeof fetch;
+      return getOk(body);
+    });
 
     const out = await readAllArgueJudges();
     expect(out).toHaveLength(3);
@@ -315,9 +322,9 @@ describe('findVerdictByConversationId', () => {
     listMock.mockResolvedValueOnce({ blobs: [] } as never);
 
     const todayLine = JSON.stringify(validVerdict({ conversation_id: id })) + '\n';
-    globalThis.fetch = vi.fn(() =>
-      Promise.resolve(new Response(todayLine, { status: 200 })),
-    ) as unknown as typeof fetch;
+    // First get() call returns today; second (yesterday) is missing.
+    getMock.mockResolvedValueOnce(getOk(todayLine));
+    getMock.mockResolvedValueOnce(getMissing());
 
     const out = await findVerdictByConversationId(id, {
       now: new Date('2026-04-25T12:00:00Z'),
@@ -343,10 +350,10 @@ describe('findVerdictByConversationId', () => {
       JSON.stringify(validVerdict({ conversation_id: id, judged_at: '2026-04-24T11:00:00.000Z', excerpt: 'older' })) +
       '\n';
     let n = 0;
-    globalThis.fetch = vi.fn(() => {
+    getMock.mockImplementation(async () => {
       const body = ++n === 1 ? todayLine : yesterdayLine;
-      return Promise.resolve(new Response(body, { status: 200 }));
-    }) as unknown as typeof fetch;
+      return getOk(body);
+    });
 
     const out = await findVerdictByConversationId(id, {
       now: new Date('2026-04-25T12:00:00Z'),
@@ -380,9 +387,7 @@ describe('URL-leak guard (AC-012)', () => {
       listMock.mockResolvedValueOnce({
         blobs: [{ pathname: 'argue-judges/2026-04-25.jsonl', url }],
       } as never);
-      globalThis.fetch = vi.fn(() =>
-        Promise.resolve(new Response(JSON.stringify(validVerdict()) + '\n', { status: 200 })),
-      ) as unknown as typeof fetch;
+      getMock.mockResolvedValueOnce(getOk(JSON.stringify(validVerdict()) + '\n'));
       putMock.mockResolvedValueOnce(undefined as never);
       await appendArgueJudge(validVerdict(), { now: new Date('2026-04-25T09:00:00Z') });
 

--- a/src/lib/argue-judge/storage.ts
+++ b/src/lib/argue-judge/storage.ts
@@ -1,5 +1,5 @@
 import 'server-only';
-import { list, put } from '@vercel/blob';
+import { get, list, put } from '@vercel/blob';
 import { ARGUE_JUDGE_VERDICT, type ArgueJudgeVerdict } from './schema';
 import { isValidDayKey, dayKeyUtc } from '@/lib/argue-log/day';
 
@@ -50,12 +50,15 @@ export async function appendArgueJudge(
 
   let body = JSON.stringify(verdict) + '\n';
   if (match) {
-    const res = await fetch(match.url);
-    if (res.ok) body = (await res.text()) + body;
+    // Private store — `fetch(match.url)` returns 403. Use SDK `get()`.
+    const got = await get(filename, { access: 'private', token });
+    if (got && got.statusCode === 200) {
+      body = (await new Response(got.stream).text()) + body;
+    }
   }
 
   await put(filename, body, {
-    access: 'public',
+    access: 'private',
     contentType: 'application/x-ndjson',
     addRandomSuffix: false,
     token,
@@ -93,9 +96,10 @@ export async function readArgueJudgeDay(day: string): Promise<ArgueJudgeVerdict[
   const existing = await list({ prefix: filename, token });
   const match = existing.blobs.find((b) => b.pathname === filename);
   if (!match) return [];
-  const res = await fetch(match.url);
-  if (!res.ok) return [];
-  const text = await res.text();
+  // Private store — `fetch(match.url)` returns 403. Use SDK `get()`.
+  const got = await get(filename, { access: 'private', token });
+  if (!got || got.statusCode !== 200) return [];
+  const text = await new Response(got.stream).text();
   const lines = text.split('\n').filter((l) => l.length > 0);
   const verdicts: ArgueJudgeVerdict[] = [];
   for (const line of lines) {

--- a/src/lib/argue-log/__tests__/storage.test.ts
+++ b/src/lib/argue-log/__tests__/storage.test.ts
@@ -4,9 +4,10 @@ vi.mock('@vercel/blob', () => ({
   list: vi.fn(),
   put: vi.fn(),
   del: vi.fn(),
+  get: vi.fn(),
 }));
 
-import { list, put, del } from '@vercel/blob';
+import { list, put, del, get } from '@vercel/blob';
 import {
   appendArgueLog,
   listArgueLogDays,
@@ -18,9 +19,19 @@ import type { ArgueLogEntry } from '../schema';
 const listMock = vi.mocked(list);
 const putMock = vi.mocked(put);
 const delMock = vi.mocked(del);
+const getMock = vi.mocked(get);
 
 const ORIG_TOKEN = process.env.BLOB_READ_WRITE_TOKEN;
-const ORIG_FETCH = globalThis.fetch;
+
+/** Build a `get()` mock result whose stream yields `body` once. */
+function getOk(body: string) {
+  return {
+    statusCode: 200,
+    stream: new Response(body).body,
+    headers: {},
+    blob: {},
+  } as never;
+}
 
 const HEX64 = 'a'.repeat(64);
 
@@ -82,13 +93,13 @@ beforeEach(() => {
   listMock.mockReset();
   putMock.mockReset();
   delMock.mockReset();
+  getMock.mockReset();
   process.env.BLOB_READ_WRITE_TOKEN = 'fake-token';
 });
 
 afterEach(() => {
   if (ORIG_TOKEN === undefined) delete process.env.BLOB_READ_WRITE_TOKEN;
   else process.env.BLOB_READ_WRITE_TOKEN = ORIG_TOKEN;
-  globalThis.fetch = ORIG_FETCH;
 });
 
 describe('appendArgueLog', () => {
@@ -119,7 +130,7 @@ describe('appendArgueLog', () => {
     expect(filename).toBe('argue-log/2026-04-24.jsonl');
     expect(String(body).trim().split('\n')).toHaveLength(1);
     expect(opts).toMatchObject({
-      access: 'public',
+      access: 'private',
       contentType: 'application/x-ndjson',
       addRandomSuffix: false,
       allowOverwrite: true,
@@ -139,9 +150,7 @@ describe('appendArgueLog', () => {
     const previousLine =
       JSON.stringify(validEntry({ timestamp: '2026-04-24T08:00:00.000Z' })) +
       '\n';
-    globalThis.fetch = vi.fn(() =>
-      Promise.resolve(new Response(previousLine)),
-    ) as unknown as typeof fetch;
+    getMock.mockResolvedValue(getOk(previousLine));
     putMock.mockResolvedValue(undefined as never);
 
     await appendArgueLog(
@@ -214,9 +223,7 @@ describe('readArgueLogDay', () => {
       '\n' +
       JSON.stringify(validEntry({ timestamp: '2026-04-24T02:00:00.000Z' })) +
       '\n';
-    globalThis.fetch = vi.fn(() =>
-      Promise.resolve(new Response(body)),
-    ) as unknown as typeof fetch;
+    getMock.mockResolvedValue(getOk(body));
 
     const out = await readArgueLogDay('2026-04-24');
     expect(out).toHaveLength(2);
@@ -238,9 +245,7 @@ describe('readArgueLogDay', () => {
       JSON.stringify(validEntry()) +
       '\n' +
       'not-even-json\n';
-    globalThis.fetch = vi.fn(() =>
-      Promise.resolve(new Response(body)),
-    ) as unknown as typeof fetch;
+    getMock.mockResolvedValue(getOk(body));
 
     const out = await readArgueLogDay('2026-04-24');
     expect(out).toHaveLength(1);
@@ -317,7 +322,7 @@ describe('URL-leak guard (AC-010)', () => {
       putMock.mockResolvedValue(undefined as never);
       await appendArgueLog(validEntry());
 
-      // Second append on existing day (goes through fetch → concat → put)
+      // Second append on existing day (goes through get → concat → put)
       listMock.mockResolvedValue({
         blobs: [
           {
@@ -326,9 +331,7 @@ describe('URL-leak guard (AC-010)', () => {
           },
         ],
       } as never);
-      globalThis.fetch = vi.fn(() =>
-        Promise.resolve(new Response(JSON.stringify(validEntry()) + '\n')),
-      ) as unknown as typeof fetch;
+      getMock.mockResolvedValue(getOk(JSON.stringify(validEntry()) + '\n'));
       await appendArgueLog(validEntry(), {
         now: new Date('2026-04-24T09:00:00Z'),
       });
@@ -345,9 +348,7 @@ describe('URL-leak guard (AC-010)', () => {
       await listArgueLogDays();
 
       // Read path
-      globalThis.fetch = vi.fn(() =>
-        Promise.resolve(new Response(JSON.stringify(validEntry()) + '\n')),
-      ) as unknown as typeof fetch;
+      getMock.mockResolvedValue(getOk(JSON.stringify(validEntry()) + '\n'));
       await readArgueLogDay('2026-04-24');
 
       // Delete path

--- a/src/lib/argue-log/storage.ts
+++ b/src/lib/argue-log/storage.ts
@@ -1,5 +1,5 @@
 import 'server-only';
-import { list, put, del } from '@vercel/blob';
+import { get, list, put, del } from '@vercel/blob';
 import { ARGUE_LOG_ENTRY, type ArgueLogEntry } from './schema';
 import { isValidDayKey, dayKeyUtc } from './day';
 
@@ -49,12 +49,16 @@ export async function appendArgueLog(
 
   let body = JSON.stringify(entry) + '\n';
   if (match) {
-    const res = await fetch(match.url);
-    if (res.ok) body = (await res.text()) + body;
+    // Private store — `fetch(match.url)` returns 403. Use SDK `get()`
+    // which signs the request with the token.
+    const got = await get(filename, { access: 'private', token });
+    if (got && got.statusCode === 200) {
+      body = (await new Response(got.stream).text()) + body;
+    }
   }
 
   await put(filename, body, {
-    access: 'public',
+    access: 'private',
     contentType: 'application/x-ndjson',
     addRandomSuffix: false,
     token,
@@ -94,9 +98,10 @@ export async function readArgueLogDay(day: string): Promise<ArgueLogEntry[]> {
   // L-002: exact pathname match.
   const match = existing.blobs.find((b) => b.pathname === filename);
   if (!match) return [];
-  const res = await fetch(match.url);
-  if (!res.ok) return [];
-  const text = await res.text();
+  // Private store — `fetch(match.url)` returns 403. Use SDK `get()`.
+  const got = await get(filename, { access: 'private', token });
+  if (!got || got.statusCode !== 200) return [];
+  const text = await new Response(got.stream).text();
   const lines = text.split('\n').filter((l) => l.length > 0);
   const entries: ArgueLogEntry[] = [];
   for (const line of lines) {

--- a/src/lib/push-back/__tests__/storage.test.ts
+++ b/src/lib/push-back/__tests__/storage.test.ts
@@ -3,27 +3,37 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 vi.mock('@vercel/blob', () => ({
   list: vi.fn(),
   put: vi.fn(),
+  get: vi.fn(),
 }));
 
-import { list, put } from '@vercel/blob';
+import { list, put, get } from '@vercel/blob';
 import { appendPushBack } from '../storage';
 
 const listMock = vi.mocked(list);
 const putMock = vi.mocked(put);
+const getMock = vi.mocked(get);
 
 const ORIG_TOKEN = process.env.BLOB_READ_WRITE_TOKEN;
-const ORIG_FETCH = globalThis.fetch;
+
+function getOk(body: string) {
+  return {
+    statusCode: 200,
+    stream: new Response(body).body,
+    headers: {},
+    blob: {},
+  } as never;
+}
 
 beforeEach(() => {
   listMock.mockReset();
   putMock.mockReset();
+  getMock.mockReset();
   process.env.BLOB_READ_WRITE_TOKEN = 'fake-token';
 });
 
 afterEach(() => {
   if (ORIG_TOKEN === undefined) delete process.env.BLOB_READ_WRITE_TOKEN;
   else process.env.BLOB_READ_WRITE_TOKEN = ORIG_TOKEN;
-  globalThis.fetch = ORIG_FETCH;
 });
 
 describe('appendPushBack', () => {
@@ -56,18 +66,19 @@ describe('appendPushBack', () => {
     listMock.mockResolvedValue({
       blobs: [{ url: 'https://blob.example/d.jsonl' }],
     } as never);
-    globalThis.fetch = vi.fn(() =>
-      Promise.resolve(new Response('{"slug":"prev","message":"p","name":"","timestamp":"T0"}\n')),
-    ) as unknown as typeof fetch;
+    getMock.mockResolvedValue(
+      getOk('{"slug":"prev","message":"p","name":"","timestamp":"T0"}\n'),
+    );
     putMock.mockResolvedValue(undefined as never);
     await appendPushBack(
       { slug: 'a', message: 'hello world!!', name: '', timestamp: 'T1' },
       { now: new Date('2026-04-22T00:00:00Z') },
     );
-    const [, body] = putMock.mock.calls[0];
+    const [, body, opts] = putMock.mock.calls[0];
     const lines = String(body).trim().split('\n');
     expect(lines).toHaveLength(2);
     expect(JSON.parse(lines[0]).slug).toBe('prev');
     expect(JSON.parse(lines[1]).slug).toBe('a');
+    expect(opts).toMatchObject({ access: 'private' });
   });
 });

--- a/src/lib/push-back/storage.ts
+++ b/src/lib/push-back/storage.ts
@@ -1,5 +1,5 @@
 import 'server-only';
-import { list, put } from '@vercel/blob';
+import { get, list, put } from '@vercel/blob';
 import type { PushBack } from './schema';
 
 const JSONL_PREFIX = 'push-back/';
@@ -33,12 +33,15 @@ export async function appendPushBack(
   const existing = await list({ prefix: filename, token });
   let body = JSON.stringify(entry) + '\n';
   if (existing.blobs.length > 0) {
-    const res = await fetch(existing.blobs[0].url);
-    if (res.ok) body = (await res.text()) + body;
+    // Private store — `fetch(blob.url)` returns 403. Use SDK `get()`.
+    const got = await get(filename, { access: 'private', token });
+    if (got && got.statusCode === 200) {
+      body = (await new Response(got.stream).text()) + body;
+    }
   }
 
   await put(filename, body, {
-    access: 'public',
+    access: 'private',
     contentType: 'application/x-ndjson',
     addRandomSuffix: false,
     token,


### PR DESCRIPTION
## Summary

The production Vercel Blob store is configured for **private access**, but every storage write in this repo passes `access: 'public'`. The SDK rejects every call with `"Cannot use public access on a private store"`. The errors are swallowed by the silent `try/catch` around `appendArgueLog` (in `src/app/api/chat/route.ts:257-262`) and equivalents in `push-back` and `argue-judge` — so the chat UI works fine, but **zero entries have been written since launch**.

Verified by direct probe: the production store currently contains 0 blobs total. Maria's holiday pushback never persisted; the daily judge sweep had nothing to read.

## Fix

- All three `put({ access: 'public', ... })` calls → `'private'`.
- Replace `fetch(blob.url)` reads (which return `403 Forbidden` against a private store) with SDK `get(pathname, { access: 'private', token })` and decode the returned `ReadableStream`.
- Affected files: `src/lib/argue-log/storage.ts`, `src/lib/argue-judge/storage.ts`, `src/lib/push-back/storage.ts`, plus their test files.
- Round-trip verified end-to-end against the **real production private store** (write → list → get → concat → put → read → delete cycle).

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test --run` — 556 specs pass
- [x] `pnpm build` clean
- [x] Manual: write/get/concat/put/delete round-trip against the production private blob store (`DMha6HFForKrlpcV…`)
- [ ] Recommend `/security-review` per CLAUDE.md (touches Vercel Blob writes)
- [ ] After merge: post-deploy, trigger one chat from the live site and confirm a new file appears under `argue-log/YYYY-MM-DD.jsonl` in the Blob dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)