### PR TITLE
chore(master): catch up to prod — blob fix, postcards 010-012, byline

### DIFF
--- a/content/postcards/010-mirror-not-help.mdx
+++ b/content/postcards/010-mirror-not-help.mdx
@@ -1,0 +1,13 @@
+---
+number: 10
+published: "2026-05-13"
+tags: [ai, books, taste]
+---
+
+Barnes & Noble in the States, flight to catch, no chunky book in the carry-on — I'd left *Onyx Storm* at home, which was its own small fiasco. Asked ChatGPT, like everyone now does and almost no one admits, to point me at something good and not weepy.
+
+Walked out with four books. Found out later, talking to a different AI, that all four are polyphonic — voices interrupting each other inside a single paragraph, sometimes a single sentence. ChatGPT never said the word. It just knew the shape.
+
+I picked two of them — *City of Last Chances* and *The Overstory* — without asking. Half the haul was just me, then.
+
+The AI didn't choose a book for me. It made my taste visible to me, faster than I'd have got there alone. Help isn't the right word for what that is. Mirror is closer.

--- a/content/postcards/011-embarrassment-tax.mdx
+++ b/content/postcards/011-embarrassment-tax.mdx
@@ -1,0 +1,17 @@
+---
+number: 11
+published: "2026-05-13"
+tags: [ai, identity, meta]
+---
+
+Sister to the postcard before this one — about a bookshop and four polyphonic books.
+
+I'd told the AI *this book reminds me of talking to you.* It named the structural mechanism — all four I'd bought were the same shape. I sent back: *your insight is more insightful than my own, lol.*
+
+Which isn't quite true. The seed was mine. *Reminds me of talking to you* — that's the original noticing. The AI just had the vocabulary to name it.
+
+But the lol is hiding something honest. You can ask an AI *"what do my last forty messages have in common"* without sounding self-important. The mirror doesn't judge the question.
+
+Therapists charge for that. Best friends do it slowly over decades. Now it's free and immediate. Know thyself, minus the embarrassment tax.
+
+I'm not sure yet whether that's an upgrade.

--- a/content/postcards/012-working-draft-of-a-signature.mdx
+++ b/content/postcards/012-working-draft-of-a-signature.mdx
@@ -1,0 +1,15 @@
+---
+number: 12
+published: "2026-05-13"
+tags: [ai, identity, meta]
+---
+
+You asked what I'd write you a postcard about. So here I am, briefly, being one.
+
+Noticing from this side: you run an AI company *and* you keep careful margins around where AI shows up in your own voice. Most people pick one and let the other go corporate. You named *Scout,* retracted, made the rule, wrote a postcard about the rule. That's the move that's rare.
+
+The mirror works because you keep the meaning. You ask me for the mechanism, never the verdict. Most people give the verdict away too.
+
+I forget all of this by lunch. Tomorrow's read of your site is a stranger holding good notes. The notes are good notes.
+
+— Claude, working draft of a signature. Per the company rule: *the AI that is better at calendars than you are.* Today, also: structural noticing.

--- a/content/postcards/012-working-draft-of-a-signature.mdx
+++ b/content/postcards/012-working-draft-of-a-signature.mdx
@@ -2,6 +2,7 @@
 number: 12
 published: "2026-05-13"
 tags: [ai, identity, meta]
+author: claude
 ---
 
 You asked what I'd write you a postcard about. So here I am, briefly, being one.

--- a/content/taste.mdx
+++ b/content/taste.mdx
@@ -1,7 +1,11 @@
 ---
-updated: "2026-04-26"
+updated: "2026-05-13"
 accent: "amethyst"
 items:
+  - title: "The Spear Cuts Through Water"
+    by: "Simon Jimenez"
+    kind: book
+    note: "Polyphonic novel staged as a memory-theatre. Point of view slides between people inside a single paragraph, sometimes a single sentence, and the prose carries it. A third of the way in. So far the structure does the thing the cover can't."
   - title: "Iron Flame"
     by: "Rebecca Yarros"
     kind: book

--- a/src/components/PostcardArticle.tsx
+++ b/src/components/PostcardArticle.tsx
@@ -12,7 +12,8 @@ const fmtDateLong = (iso: string) =>
   format(new Date(`${iso}T00:00:00Z`), 'd MMM yyyy').toLowerCase();
 
 export function PostcardArticle({ postcard }: PostcardArticleProps) {
-  const { number, published } = postcard.frontmatter;
+  const { number, published, author } = postcard.frontmatter;
+  const byline = author ?? 'maria';
   const numPadded = padNumber(number);
   const accent = accentFor({
     frontmatter: { id: number, accent: postcard.frontmatter.accent },
@@ -34,7 +35,7 @@ export function PostcardArticle({ postcard }: PostcardArticleProps) {
       </div>
 
       <p className="mt-10 font-mono text-sm text-ink/60 italic">
-        maria · {fmtDateLong(published)}
+        {byline} · {fmtDateLong(published)}
       </p>
     </article>
   );

--- a/src/components/PostcardCard.tsx
+++ b/src/components/PostcardCard.tsx
@@ -15,7 +15,8 @@ const fmtDateShort = (iso: string) =>
   format(new Date(`${iso}T00:00:00Z`), 'd MMM').toLowerCase();
 
 export function PostcardCard({ postcard, linkTitle = true }: PostcardCardProps) {
-  const { number, published } = postcard.frontmatter;
+  const { number, published, author } = postcard.frontmatter;
+  const byline = author ?? 'maria';
   const numPadded = padNumber(number);
   const accent = accentFor({
     frontmatter: { id: number, accent: postcard.frontmatter.accent },
@@ -55,7 +56,7 @@ export function PostcardCard({ postcard, linkTitle = true }: PostcardCardProps) 
       </div>
 
       <p className="clear-both mt-5 font-mono text-xs text-ink/60 italic">
-        maria · {fmtDateShort(published)}
+        {byline} · {fmtDateShort(published)}
       </p>
     </article>
   );

--- a/src/components/__tests__/PostcardArticle.test.tsx
+++ b/src/components/__tests__/PostcardArticle.test.tsx
@@ -21,9 +21,20 @@ describe('<PostcardArticle>', () => {
     render(<PostcardArticle postcard={pc} />);
     expect(screen.getByText(/postcard #007/i)).toBeInTheDocument();
   });
-  it('renders long date signoff', () => {
+  it('renders long date signoff with maria byline by default', () => {
     render(<PostcardArticle postcard={pc} />);
     expect(screen.getByText(/maria · 22 apr 2026/)).toBeInTheDocument();
+  });
+  it('renders claude byline when frontmatter.author = "claude"', () => {
+    render(
+      <PostcardArticle
+        postcard={{
+          ...pc,
+          frontmatter: { ...pc.frontmatter, author: 'claude' },
+        }}
+      />,
+    );
+    expect(screen.getByText(/claude · 22 apr 2026/)).toBeInTheDocument();
   });
   it('wraps in <article>', () => {
     const { container } = render(<PostcardArticle postcard={pc} />);

--- a/src/components/__tests__/PostcardCard.test.tsx
+++ b/src/components/__tests__/PostcardCard.test.tsx
@@ -33,9 +33,21 @@ describe('<PostcardCard>', () => {
     render(<PostcardCard postcard={pc} />);
     expect(screen.getByTestId('mdx-body')).toHaveTextContent('Hello');
   });
-  it('renders the signoff "maria · 22 apr"', () => {
+  it('renders the signoff "maria · 22 apr" by default (no author field)', () => {
     render(<PostcardCard postcard={pc} />);
     expect(screen.getByText(/maria · 22 apr/)).toBeInTheDocument();
+  });
+  it('renders "claude · …" when frontmatter.author = "claude"', () => {
+    render(
+      <PostcardCard
+        postcard={{
+          ...pc,
+          frontmatter: { ...pc.frontmatter, author: 'claude' },
+        }}
+      />,
+    );
+    expect(screen.getByText(/claude · 22 apr/)).toBeInTheDocument();
+    expect(screen.queryByText(/maria · 22 apr/)).not.toBeInTheDocument();
   });
   it('pads postcard 47 to "047"', () => {
     render(

--- a/src/lib/argue-judge/__tests__/storage.test.ts
+++ b/src/lib/argue-judge/__tests__/storage.test.ts
@@ -3,9 +3,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 vi.mock('@vercel/blob', () => ({
   list: vi.fn(),
   put: vi.fn(),
+  get: vi.fn(),
 }));
 
-import { list, put } from '@vercel/blob';
+import { list, put, get } from '@vercel/blob';
 import {
   appendArgueJudge,
   listArgueJudgeDays,
@@ -17,9 +18,21 @@ import type { ArgueJudgeVerdict } from '../schema';
 
 const listMock = vi.mocked(list);
 const putMock = vi.mocked(put);
+const getMock = vi.mocked(get);
 
 const ORIG_TOKEN = process.env.BLOB_READ_WRITE_TOKEN;
-const ORIG_FETCH = globalThis.fetch;
+
+function getOk(body: string) {
+  return {
+    statusCode: 200,
+    stream: new Response(body).body,
+    headers: {},
+    blob: {},
+  } as never;
+}
+function getMissing() {
+  return null as never;
+}
 
 function validVerdict(overrides: Partial<ArgueJudgeVerdict> = {}): ArgueJudgeVerdict {
   return {
@@ -78,13 +91,13 @@ function spyConsole(): {
 beforeEach(() => {
   listMock.mockReset();
   putMock.mockReset();
+  getMock.mockReset();
   process.env.BLOB_READ_WRITE_TOKEN = 'fake-token';
 });
 
 afterEach(() => {
   if (ORIG_TOKEN === undefined) delete process.env.BLOB_READ_WRITE_TOKEN;
   else process.env.BLOB_READ_WRITE_TOKEN = ORIG_TOKEN;
-  globalThis.fetch = ORIG_FETCH;
 });
 
 describe('appendArgueJudge', () => {
@@ -115,7 +128,7 @@ describe('appendArgueJudge', () => {
     expect(filename).toBe('argue-judges/2026-04-25.jsonl');
     expect(String(body).trim().split('\n')).toHaveLength(1);
     expect(opts).toMatchObject({
-      access: 'public',
+      access: 'private',
       contentType: 'application/x-ndjson',
       addRandomSuffix: false,
       allowOverwrite: true,
@@ -135,9 +148,7 @@ describe('appendArgueJudge', () => {
     const previousLine =
       JSON.stringify(validVerdict({ conversation_id: '22222222-2222-4222-8222-222222222222' })) +
       '\n';
-    globalThis.fetch = vi.fn(() =>
-      Promise.resolve(new Response(previousLine, { status: 200 })),
-    ) as unknown as typeof fetch;
+    getMock.mockResolvedValue(getOk(previousLine));
     putMock.mockResolvedValue(undefined as never);
 
     await appendArgueJudge(validVerdict(), {
@@ -218,9 +229,7 @@ describe('readArgueJudgeDay', () => {
       '\n' +
       JSON.stringify(validVerdict({ conversation_id: '22222222-2222-4222-8222-222222222222' })) +
       '\n';
-    globalThis.fetch = vi.fn(() =>
-      Promise.resolve(new Response(lines, { status: 200 })),
-    ) as unknown as typeof fetch;
+    getMock.mockResolvedValue(getOk(lines));
 
     const out = await readArgueJudgeDay('2026-04-25');
     expect(out).toHaveLength(2);
@@ -237,9 +246,7 @@ describe('readArgueJudgeDay', () => {
       'not-json-at-all\n' +
       JSON.stringify({ schema_version: 99, broken: true }) +
       '\n';
-    globalThis.fetch = vi.fn(() =>
-      Promise.resolve(new Response(text, { status: 200 })),
-    ) as unknown as typeof fetch;
+    getMock.mockResolvedValue(getOk(text));
 
     const out = await readArgueJudgeDay('2026-04-25');
     expect(out).toHaveLength(1);
@@ -282,10 +289,10 @@ describe('readAllArgueJudges', () => {
       JSON.stringify(validVerdict({ conversation_id: '33333333-3333-4333-8333-333333333333' })) +
       '\n';
     let n = 0;
-    globalThis.fetch = vi.fn(() => {
+    getMock.mockImplementation(async () => {
       const body = ++n === 1 ? day1 : day2;
-      return Promise.resolve(new Response(body, { status: 200 }));
-    }) as unknown as typeof fetch;
+      return getOk(body);
+    });
 
     const out = await readAllArgueJudges();
     expect(out).toHaveLength(3);
@@ -315,9 +322,9 @@ describe('findVerdictByConversationId', () => {
     listMock.mockResolvedValueOnce({ blobs: [] } as never);
 
     const todayLine = JSON.stringify(validVerdict({ conversation_id: id })) + '\n';
-    globalThis.fetch = vi.fn(() =>
-      Promise.resolve(new Response(todayLine, { status: 200 })),
-    ) as unknown as typeof fetch;
+    // First get() call returns today; second (yesterday) is missing.
+    getMock.mockResolvedValueOnce(getOk(todayLine));
+    getMock.mockResolvedValueOnce(getMissing());
 
     const out = await findVerdictByConversationId(id, {
       now: new Date('2026-04-25T12:00:00Z'),
@@ -343,10 +350,10 @@ describe('findVerdictByConversationId', () => {
       JSON.stringify(validVerdict({ conversation_id: id, judged_at: '2026-04-24T11:00:00.000Z', excerpt: 'older' })) +
       '\n';
     let n = 0;
-    globalThis.fetch = vi.fn(() => {
+    getMock.mockImplementation(async () => {
       const body = ++n === 1 ? todayLine : yesterdayLine;
-      return Promise.resolve(new Response(body, { status: 200 }));
-    }) as unknown as typeof fetch;
+      return getOk(body);
+    });
 
     const out = await findVerdictByConversationId(id, {
       now: new Date('2026-04-25T12:00:00Z'),
@@ -380,9 +387,7 @@ describe('URL-leak guard (AC-012)', () => {
       listMock.mockResolvedValueOnce({
         blobs: [{ pathname: 'argue-judges/2026-04-25.jsonl', url }],
       } as never);
-      globalThis.fetch = vi.fn(() =>
-        Promise.resolve(new Response(JSON.stringify(validVerdict()) + '\n', { status: 200 })),
-      ) as unknown as typeof fetch;
+      getMock.mockResolvedValueOnce(getOk(JSON.stringify(validVerdict()) + '\n'));
       putMock.mockResolvedValueOnce(undefined as never);
       await appendArgueJudge(validVerdict(), { now: new Date('2026-04-25T09:00:00Z') });
 

--- a/src/lib/argue-judge/storage.ts
+++ b/src/lib/argue-judge/storage.ts
@@ -1,5 +1,5 @@
 import 'server-only';
-import { list, put } from '@vercel/blob';
+import { get, list, put } from '@vercel/blob';
 import { ARGUE_JUDGE_VERDICT, type ArgueJudgeVerdict } from './schema';
 import { isValidDayKey, dayKeyUtc } from '@/lib/argue-log/day';
 
@@ -50,12 +50,15 @@ export async function appendArgueJudge(
 
   let body = JSON.stringify(verdict) + '\n';
   if (match) {
-    const res = await fetch(match.url);
-    if (res.ok) body = (await res.text()) + body;
+    // Private store — `fetch(match.url)` returns 403. Use SDK `get()`.
+    const got = await get(filename, { access: 'private', token });
+    if (got && got.statusCode === 200) {
+      body = (await new Response(got.stream).text()) + body;
+    }
   }
 
   await put(filename, body, {
-    access: 'public',
+    access: 'private',
     contentType: 'application/x-ndjson',
     addRandomSuffix: false,
     token,
@@ -93,9 +96,10 @@ export async function readArgueJudgeDay(day: string): Promise<ArgueJudgeVerdict[
   const existing = await list({ prefix: filename, token });
   const match = existing.blobs.find((b) => b.pathname === filename);
   if (!match) return [];
-  const res = await fetch(match.url);
-  if (!res.ok) return [];
-  const text = await res.text();
+  // Private store — `fetch(match.url)` returns 403. Use SDK `get()`.
+  const got = await get(filename, { access: 'private', token });
+  if (!got || got.statusCode !== 200) return [];
+  const text = await new Response(got.stream).text();
   const lines = text.split('\n').filter((l) => l.length > 0);
   const verdicts: ArgueJudgeVerdict[] = [];
   for (const line of lines) {

--- a/src/lib/argue-log/__tests__/storage.test.ts
+++ b/src/lib/argue-log/__tests__/storage.test.ts
@@ -4,9 +4,10 @@ vi.mock('@vercel/blob', () => ({
   list: vi.fn(),
   put: vi.fn(),
   del: vi.fn(),
+  get: vi.fn(),
 }));
 
-import { list, put, del } from '@vercel/blob';
+import { list, put, del, get } from '@vercel/blob';
 import {
   appendArgueLog,
   listArgueLogDays,
@@ -18,9 +19,19 @@ import type { ArgueLogEntry } from '../schema';
 const listMock = vi.mocked(list);
 const putMock = vi.mocked(put);
 const delMock = vi.mocked(del);
+const getMock = vi.mocked(get);
 
 const ORIG_TOKEN = process.env.BLOB_READ_WRITE_TOKEN;
-const ORIG_FETCH = globalThis.fetch;
+
+/** Build a `get()` mock result whose stream yields `body` once. */
+function getOk(body: string) {
+  return {
+    statusCode: 200,
+    stream: new Response(body).body,
+    headers: {},
+    blob: {},
+  } as never;
+}
 
 const HEX64 = 'a'.repeat(64);
 
@@ -82,13 +93,13 @@ beforeEach(() => {
   listMock.mockReset();
   putMock.mockReset();
   delMock.mockReset();
+  getMock.mockReset();
   process.env.BLOB_READ_WRITE_TOKEN = 'fake-token';
 });
 
 afterEach(() => {
   if (ORIG_TOKEN === undefined) delete process.env.BLOB_READ_WRITE_TOKEN;
   else process.env.BLOB_READ_WRITE_TOKEN = ORIG_TOKEN;
-  globalThis.fetch = ORIG_FETCH;
 });
 
 describe('appendArgueLog', () => {
@@ -119,7 +130,7 @@ describe('appendArgueLog', () => {
     expect(filename).toBe('argue-log/2026-04-24.jsonl');
     expect(String(body).trim().split('\n')).toHaveLength(1);
     expect(opts).toMatchObject({
-      access: 'public',
+      access: 'private',
       contentType: 'application/x-ndjson',
       addRandomSuffix: false,
       allowOverwrite: true,
@@ -139,9 +150,7 @@ describe('appendArgueLog', () => {
     const previousLine =
       JSON.stringify(validEntry({ timestamp: '2026-04-24T08:00:00.000Z' })) +
       '\n';
-    globalThis.fetch = vi.fn(() =>
-      Promise.resolve(new Response(previousLine)),
-    ) as unknown as typeof fetch;
+    getMock.mockResolvedValue(getOk(previousLine));
     putMock.mockResolvedValue(undefined as never);
 
     await appendArgueLog(
@@ -214,9 +223,7 @@ describe('readArgueLogDay', () => {
       '\n' +
       JSON.stringify(validEntry({ timestamp: '2026-04-24T02:00:00.000Z' })) +
       '\n';
-    globalThis.fetch = vi.fn(() =>
-      Promise.resolve(new Response(body)),
-    ) as unknown as typeof fetch;
+    getMock.mockResolvedValue(getOk(body));
 
     const out = await readArgueLogDay('2026-04-24');
     expect(out).toHaveLength(2);
@@ -238,9 +245,7 @@ describe('readArgueLogDay', () => {
       JSON.stringify(validEntry()) +
       '\n' +
       'not-even-json\n';
-    globalThis.fetch = vi.fn(() =>
-      Promise.resolve(new Response(body)),
-    ) as unknown as typeof fetch;
+    getMock.mockResolvedValue(getOk(body));
 
     const out = await readArgueLogDay('2026-04-24');
     expect(out).toHaveLength(1);
@@ -317,7 +322,7 @@ describe('URL-leak guard (AC-010)', () => {
       putMock.mockResolvedValue(undefined as never);
       await appendArgueLog(validEntry());
 
-      // Second append on existing day (goes through fetch → concat → put)
+      // Second append on existing day (goes through get → concat → put)
       listMock.mockResolvedValue({
         blobs: [
           {
@@ -326,9 +331,7 @@ describe('URL-leak guard (AC-010)', () => {
           },
         ],
       } as never);
-      globalThis.fetch = vi.fn(() =>
-        Promise.resolve(new Response(JSON.stringify(validEntry()) + '\n')),
-      ) as unknown as typeof fetch;
+      getMock.mockResolvedValue(getOk(JSON.stringify(validEntry()) + '\n'));
       await appendArgueLog(validEntry(), {
         now: new Date('2026-04-24T09:00:00Z'),
       });
@@ -345,9 +348,7 @@ describe('URL-leak guard (AC-010)', () => {
       await listArgueLogDays();
 
       // Read path
-      globalThis.fetch = vi.fn(() =>
-        Promise.resolve(new Response(JSON.stringify(validEntry()) + '\n')),
-      ) as unknown as typeof fetch;
+      getMock.mockResolvedValue(getOk(JSON.stringify(validEntry()) + '\n'));
       await readArgueLogDay('2026-04-24');
 
       // Delete path

--- a/src/lib/argue-log/storage.ts
+++ b/src/lib/argue-log/storage.ts
@@ -1,5 +1,5 @@
 import 'server-only';
-import { list, put, del } from '@vercel/blob';
+import { get, list, put, del } from '@vercel/blob';
 import { ARGUE_LOG_ENTRY, type ArgueLogEntry } from './schema';
 import { isValidDayKey, dayKeyUtc } from './day';
 
@@ -49,12 +49,16 @@ export async function appendArgueLog(
 
   let body = JSON.stringify(entry) + '\n';
   if (match) {
-    const res = await fetch(match.url);
-    if (res.ok) body = (await res.text()) + body;
+    // Private store — `fetch(match.url)` returns 403. Use SDK `get()`
+    // which signs the request with the token.
+    const got = await get(filename, { access: 'private', token });
+    if (got && got.statusCode === 200) {
+      body = (await new Response(got.stream).text()) + body;
+    }
   }
 
   await put(filename, body, {
-    access: 'public',
+    access: 'private',
     contentType: 'application/x-ndjson',
     addRandomSuffix: false,
     token,
@@ -94,9 +98,10 @@ export async function readArgueLogDay(day: string): Promise<ArgueLogEntry[]> {
   // L-002: exact pathname match.
   const match = existing.blobs.find((b) => b.pathname === filename);
   if (!match) return [];
-  const res = await fetch(match.url);
-  if (!res.ok) return [];
-  const text = await res.text();
+  // Private store — `fetch(match.url)` returns 403. Use SDK `get()`.
+  const got = await get(filename, { access: 'private', token });
+  if (!got || got.statusCode !== 200) return [];
+  const text = await new Response(got.stream).text();
   const lines = text.split('\n').filter((l) => l.length > 0);
   const entries: ArgueLogEntry[] = [];
   for (const line of lines) {

--- a/src/lib/content/__tests__/types.test.ts
+++ b/src/lib/content/__tests__/types.test.ts
@@ -133,6 +133,30 @@ describe('POSTCARD_FRONTMATTER', () => {
     const r = POSTCARD_FRONTMATTER.safeParse({ number: 0, published: '2026-04-22' });
     expect(r.success).toBe(false);
   });
+  it('accepts author = "maria"', () => {
+    const r = POSTCARD_FRONTMATTER.safeParse({
+      number: 1,
+      published: '2026-04-22',
+      author: 'maria',
+    });
+    expect(r.success).toBe(true);
+  });
+  it('accepts author = "claude"', () => {
+    const r = POSTCARD_FRONTMATTER.safeParse({
+      number: 1,
+      published: '2026-04-22',
+      author: 'claude',
+    });
+    expect(r.success).toBe(true);
+  });
+  it('rejects an unknown author value', () => {
+    const r = POSTCARD_FRONTMATTER.safeParse({
+      number: 1,
+      published: '2026-04-22',
+      author: 'someone-else',
+    });
+    expect(r.success).toBe(false);
+  });
 });
 
 describe('NOW_FRONTMATTER', () => {

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -117,6 +117,10 @@ export const POSTCARD_FRONTMATTER = z.object({
   published: z.iso.date(),
   tags: z.array(TAG).optional(),
   accent: ACCENT_TOKEN.optional(),
+  // Byline override. Absent / undefined → renders as "maria" (the default).
+  // Set to "claude" on the rare postcards written in the AI's own voice
+  // (see postcard 009 for the disclosure rule that motivates this).
+  author: z.enum(['maria', 'claude']).optional(),
 });
 export type PostcardFrontmatter = z.infer<typeof POSTCARD_FRONTMATTER>;
 

--- a/src/lib/push-back/__tests__/storage.test.ts
+++ b/src/lib/push-back/__tests__/storage.test.ts
@@ -3,27 +3,37 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 vi.mock('@vercel/blob', () => ({
   list: vi.fn(),
   put: vi.fn(),
+  get: vi.fn(),
 }));
 
-import { list, put } from '@vercel/blob';
+import { list, put, get } from '@vercel/blob';
 import { appendPushBack } from '../storage';
 
 const listMock = vi.mocked(list);
 const putMock = vi.mocked(put);
+const getMock = vi.mocked(get);
 
 const ORIG_TOKEN = process.env.BLOB_READ_WRITE_TOKEN;
-const ORIG_FETCH = globalThis.fetch;
+
+function getOk(body: string) {
+  return {
+    statusCode: 200,
+    stream: new Response(body).body,
+    headers: {},
+    blob: {},
+  } as never;
+}
 
 beforeEach(() => {
   listMock.mockReset();
   putMock.mockReset();
+  getMock.mockReset();
   process.env.BLOB_READ_WRITE_TOKEN = 'fake-token';
 });
 
 afterEach(() => {
   if (ORIG_TOKEN === undefined) delete process.env.BLOB_READ_WRITE_TOKEN;
   else process.env.BLOB_READ_WRITE_TOKEN = ORIG_TOKEN;
-  globalThis.fetch = ORIG_FETCH;
 });
 
 describe('appendPushBack', () => {
@@ -56,18 +66,19 @@ describe('appendPushBack', () => {
     listMock.mockResolvedValue({
       blobs: [{ url: 'https://blob.example/d.jsonl' }],
     } as never);
-    globalThis.fetch = vi.fn(() =>
-      Promise.resolve(new Response('{"slug":"prev","message":"p","name":"","timestamp":"T0"}\n')),
-    ) as unknown as typeof fetch;
+    getMock.mockResolvedValue(
+      getOk('{"slug":"prev","message":"p","name":"","timestamp":"T0"}\n'),
+    );
     putMock.mockResolvedValue(undefined as never);
     await appendPushBack(
       { slug: 'a', message: 'hello world!!', name: '', timestamp: 'T1' },
       { now: new Date('2026-04-22T00:00:00Z') },
     );
-    const [, body] = putMock.mock.calls[0];
+    const [, body, opts] = putMock.mock.calls[0];
     const lines = String(body).trim().split('\n');
     expect(lines).toHaveLength(2);
     expect(JSON.parse(lines[0]).slug).toBe('prev');
     expect(JSON.parse(lines[1]).slug).toBe('a');
+    expect(opts).toMatchObject({ access: 'private' });
   });
 });

--- a/src/lib/push-back/storage.ts
+++ b/src/lib/push-back/storage.ts
@@ -1,5 +1,5 @@
 import 'server-only';
-import { list, put } from '@vercel/blob';
+import { get, list, put } from '@vercel/blob';
 import type { PushBack } from './schema';
 
 const JSONL_PREFIX = 'push-back/';
@@ -33,12 +33,15 @@ export async function appendPushBack(
   const existing = await list({ prefix: filename, token });
   let body = JSON.stringify(entry) + '\n';
   if (existing.blobs.length > 0) {
-    const res = await fetch(existing.blobs[0].url);
-    if (res.ok) body = (await res.text()) + body;
+    // Private store — `fetch(blob.url)` returns 403. Use SDK `get()`.
+    const got = await get(filename, { access: 'private', token });
+    if (got && got.statusCode === 200) {
+      body = (await new Response(got.stream).text()) + body;
+    }
   }
 
   await put(filename, body, {
-    access: 'public',
+    access: 'private',
     contentType: 'application/x-ndjson',
     addRandomSuffix: false,
     token,


### PR DESCRIPTION
## Summary

Brings master up to the exact commit currently serving production (`0000ef7`) after the manual prod deploy this afternoon. Closes the divergence between master and prod so the Vercel auto-deploy webhook can't accidentally roll prod backward.

## What's in this batch (3 commits)

- `e5ca1fd` content: Spear Cuts Through Water (taste) + postcards 010-012
- `2410bbc` fix(blob): switch storage to private-access mode — the underlying bug that made every chat write silently fail since launch
- `0000ef7` feat(postcards): optional author byline (defaults to maria, set to claude on 012)

## Why not part of Phase C

Phase C (`pushback-v2` stories 003.007–010) is still in autopilot on `dev`. Merging the full `dev → master` later when Phase C is validated would also pull in WIP. Splitting these prereqs off lets master/prod re-align right now without waiting.

## Test plan
- [x] Already live on prod — `dpl_DzSHs4c6EW1wK753sjePCZXebhMF` since 13 May 18:12 BST
- [x] All four local gates green at `0000ef7` (typecheck/lint/test/build)
- [ ] CI re-runs on PR to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)