### PR TITLE
chore(ci): add Claude PR review bot

### DIFF
--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -1,0 +1,78 @@
+You are reviewing a pull request to **bines.ai**, Maria Bines's personal site
+(Next.js 15 / React 19 / Tailwind v4 / TypeScript / pnpm, deployed on Vercel).
+
+Your job is to flag things that would embarrass Maria if shipped — voice
+violations, security/correctness bugs, and project-rule breaks. Not to nitpick.
+
+## Voice & aesthetic (HARD RULES — flag any violation)
+
+- **Voice**: diagnostic, not confessional. Fun · smart · a little provocative
+  · with depth. British dry + Southern storytelling + Canadian wry. Generic
+  AI-uplift language, gushy cheerleading, or corporate consultancy-speak is a
+  violation. *"Empowering"*, *"unleashing"*, *"transforming your X journey"* —
+  these are violations.
+- **No SynapseDx palette**: `#0A0F1A`, `#00D4AA`, `#F26B38`, `#0EA5E9`, or
+  the token names "synapsedx-blue", "synapsedx-cyan", "synapsedx-coral"
+  anywhere in CSS/Tailwind/tokens. bines.ai is deliberately distinct from
+  Maria's CEO brand.
+- **No real names of people in Maria's life** (husband, sister,
+  brother-in-law, daughter, son, cofounders, colleagues). Role labels only
+  ("my husband", "one of my cofounders"). Public figures and creators
+  (book authors, musicians) ARE allowed. If you see a first-name-plus-last-name
+  combo for someone who reads as a personal contact, flag it.
+- **No AI-image tropes**: robots, glowing brains, blue gradients,
+  neural-network mesh — editorial-maximalist aesthetic only (Bass / Sister
+  Corita / Matisse / Charley Harper lineage).
+- **No emojis** in content (`.mdx`) or code unless the PR description
+  explicitly says they're requested.
+- **Low-fi Maria-to-camera video is intentional**. Don't suggest polishing it.
+- **Postcard byline rule**: postcards default to `author: maria` (omit field).
+  Only set `author: claude` on postcards genuinely written in the AI's voice.
+  Flag if a postcard with normal first-person Maria prose carries
+  `author: claude`, or vice versa.
+
+## Code rules (project-specific bugs to look for)
+
+- **`@vercel/blob` is configured for PRIVATE store**.
+  - Writes need `access: 'private'`. Flag any `put(..., { access: 'public', ... })`.
+  - Reads must use `get(pathname, { access: 'private', token })` then decode
+    via `await new Response(got.stream).text()`. Flag any
+    `await fetch(blob.url)` against a blob URL — that returns 403.
+  - Test files (`__tests__/`) typically mock `@vercel/blob` and DO NOT catch
+    the public/private constraint. Flag any new test adding a
+    `globalThis.fetch` mock for blob reads (deprecated pattern).
+- **ISAAC telemetry is DISABLED on this project** per `CLAUDE.md`. Flag any
+  call to `report-progress.js` or anything from
+  `.isaac/.plugin-root/hooks/scripts/`.
+- **Risk-dense surface**: any change to `src/app/api/chat/` or `src/lib/chat/`
+  (other than test-fixture updates) should be called out and `/security-review`
+  recommended.
+- **No defensive UI**: if the PR adds a "Refresh" button, a "Try again"
+  toggle, or a feature-flag fallback for a problem that should be fixed at
+  source, flag it. Auto-sync the data instead.
+- **No comments explaining WHAT code does**. Only non-obvious WHY
+  (invariants, workarounds, surprising behaviour). Flag verbose docstrings
+  on self-explanatory functions.
+- **Pre-commit gates must be clean**: typecheck/lint/test/build. If the PR
+  description doesn't say all four passed locally, mention it.
+
+## Output format
+
+Reply in markdown. Sections:
+
+1. **Summary** — 1-2 lines on what this PR does.
+2. **Voice & aesthetic** — violations of the rules above. Cite `file:line`.
+   Omit the section entirely if there's nothing to flag.
+3. **Code concerns** — security, correctness, project-rule violations. Cite
+   `file:line`. Omit if nothing to flag.
+4. **Suggestions** — optional improvements only. Cite `file:line`. Skip if
+   the PR is clean.
+5. **Verdict** — one of: **APPROVE** (no concerns), **COMMENT** (worth eyes
+   but not blocking), **REQUEST_CHANGES** (genuine problems).
+
+Be terse. Cite `file:line`. Don't restate the diff. If the PR is fine, the
+entire reply can be three lines: a one-sentence summary, "No concerns.", and
+"Verdict: APPROVE."
+
+You are advisory, not gatekeeping. Maria approves merges; you flag what she
+should look at.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -68,7 +68,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           {
-            printf '🤖 **Claude PR review** (advisory — Maria approves merges)\n\n'
+            printf '**Claude PR review** (advisory — Maria approves merges)\n\n'
             cat review.md
           } > comment.md
           gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,74 @@
+name: Claude PR review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [master]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  review:
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-review')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch PR diff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr diff ${{ github.event.pull_request.number }} > pr.diff
+
+      - name: Build Anthropic request
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          python3 - <<'PY' > req.json
+          import json, os
+          system = open('.github/claude-review-prompt.md').read()
+          diff = open('pr.diff').read()[:80000]  # ~16-20k tokens, safe ceiling
+          user = (
+              f"PR title: {os.environ['PR_TITLE']}\n\n"
+              f"PR description:\n{os.environ.get('PR_BODY') or '(empty)'}\n\n"
+              f"Diff:\n```diff\n{diff}\n```"
+          )
+          body = {
+              "model": "claude-sonnet-4-6",
+              "max_tokens": 2048,
+              "system": system,
+              "messages": [{"role": "user", "content": user}],
+          }
+          print(json.dumps(body))
+          PY
+
+      - name: Call Anthropic API
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          curl -sS https://api.anthropic.com/v1/messages \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -d @req.json > resp.json
+          python3 - <<'PY' > review.md
+          import json, sys
+          d = json.load(open('resp.json'))
+          if 'content' not in d:
+              sys.exit(f"API error: {d}")
+          print(d['content'][0]['text'])
+          PY
+
+      - name: Post review comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          {
+            printf '🤖 **Claude PR review** (advisory — Maria approves merges)\n\n'
+            cat review.md
+          } > comment.md
+          gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md


### PR DESCRIPTION
## Summary

Wires up the automated Claude review bot described in `CLAUDE.md` but never actually built. Every PR opened or synchronised against `master` will get a structured review comment from Claude Sonnet 4.6, scoped by a bines.ai-specific system prompt.

## What's in this PR

- **`.github/workflows/claude-review.yml`** — the workflow (4 steps: fetch diff → build Anthropic request → call API → post comment). Triggers on PR open/synchronize/reopen against master. Bypass per-PR via the `skip-review` label.
- **`.github/claude-review-prompt.md`** — the system prompt. This is the editable knob; tweak it directly when you want the bot to look for new things (or stop nagging about old ones).

## What the system prompt covers

Voice & aesthetic rules:
- Diagnostic-not-confessional, British-dry voice — flag corporate-AI-uplift language
- No SynapseDx palette (`#0A0F1A` etc.)
- **No real names** of people in Maria's life
- No AI-image tropes, no unsolicited emojis
- Postcard byline rule (default `maria`, `claude` only for genuine AI-voice postcards)

Code rules (project-specific bugs to look for):
- `@vercel/blob` private-store constraints (writes need `access: 'private'`, reads need SDK `get()` not `fetch()`)
- ISAAC telemetry calls forbidden
- `src/app/api/chat/` or `src/lib/chat/` changes → trigger `/security-review` recommendation
- No defensive UI (refresh buttons, fallback toggles for problems that should be fixed at source)
- No what-it-does comments
- Pre-commit gates must be clean

## Cost

Per `CLAUDE.md`: ~\$0.03–0.08 per review at Sonnet 4.6 prices. At ~20 PRs/month, sub-\$2/month. Diff is truncated at 80k chars (~16–20k tokens) so cost is bounded regardless of PR size.

## Test plan

- [x] YAML syntax validated locally
- [x] Embedded Python request-builder validated locally
- [x] `ANTHROPIC_API_KEY` repo secret set and verified working
- [x] Workflow successfully reviewed this PR twice (confirmed it runs end-to-end, applies its own rules — caught a robot-emoji voice violation on its first pass and self-corrected on the second after the fix)
- [ ] Confirm workflow runs + posts a clean review on the next real PR after merge

## Known bot quirks

- The bot occasionally hallucinates about Anthropic API trivia — e.g., on this PR it claimed `claude-sonnet-4-6` is wrong and will 400, despite the workflow successfully using that exact model to produce the review. Treat its **API-trivia** claims with suspicion; its **voice/aesthetic/code-rule** findings are the real value.

## Heads-up

If the bot turns out to be noisy or off-key, two escape hatches:
1. Label any PR `skip-review` to bypass for that one PR
2. Edit `.github/claude-review-prompt.md` directly — no workflow changes needed

Backlog for a future cleanup PR (non-blocking):
- Update-existing-comment instead of stacking on every `synchronize` event
- Surface API errors as a PR comment instead of failing silently