### PR TITLE
chore(review-bot): tell the bot to trust the model id

### DIFF
--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -56,6 +56,18 @@ violations, security/correctness bugs, and project-rule breaks. Not to nitpick.
 - **Pre-commit gates must be clean**: typecheck/lint/test/build. If the PR
   description doesn't say all four passed locally, mention it.
 
+## Things NOT to flag (known false positives)
+
+- **Anthropic model identifiers**: `claude-opus-4-7`, `claude-sonnet-4-6`,
+  `claude-haiku-4-5-20251001` are all valid current model IDs. The string
+  `claude-sonnet-4-6` in `.github/workflows/claude-review.yml` is the
+  intended model for this very workflow — do **not** claim it's a typo for
+  `4-5` or that it will 400. Your training data predates this release.
+- More broadly: don't make confident claims about Anthropic API trivia
+  (model slugs, header names, parameter formats) unless the diff itself
+  ships the evidence. If you're unsure whether something is wrong, say so
+  and leave the verdict at COMMENT, not REQUEST_CHANGES.
+
 ## Output format
 
 Reply in markdown. Sections:


### PR DESCRIPTION
## Summary

Quick fix for the Claude PR review bot. On PR #41 (its own creation), the bot posted REQUEST_CHANGES with a confident claim that \`claude-sonnet-4-6\` is wrong and should be \`claude-sonnet-4-5\` — despite the workflow successfully using that exact model to produce the review.

Maria's training-data window predates Sonnet 4.6 / Opus 4.7 / Haiku 4.5, so the bot will keep doing this on every CI-touching PR unless we tell it not to.

## What's in this PR

One edit to \`.github/claude-review-prompt.md\` — a new **"Things NOT to flag (known false positives)"** section that:

1. Whitelists \`claude-opus-4-7\`, \`claude-sonnet-4-6\`, \`claude-haiku-4-5-*\` as valid current model ids.
2. Tells the bot not to make confident claims about Anthropic API trivia (model slugs, header names, parameter formats) without evidence in the diff — and to drop to COMMENT rather than REQUEST_CHANGES when unsure.

## Test plan

- [x] Diff is one section addition to the system-prompt file (no workflow change, no code change)
- [ ] Apply \`skip-review\` label so the bot doesn't review its own prompt edit
- [ ] After merge, future PRs that touch \`.github/workflows/claude-review.yml\` (or any model-id reference) should no longer get a REQUEST_CHANGES on the model string

🤖 Generated with [Claude Code](https://claude.com/claude-code)