### PR TITLE
feat(now): May 2026 refresh — the mother of a married woman

### DIFF
--- a/content/now-archive/2026-04-26.mdx
+++ b/content/now-archive/2026-04-26.mdx
@@ -1,0 +1,23 @@
+---
+updated: "2026-04-26"
+currently: "Everything everywhere all at once"
+accent: "topaz"
+---
+
+I am doing more things at once than I should be. All of them with AI as the partner I never had.
+
+Selling for SynapseDx, which does not come naturally to me. AI does the part where you read the news, the financials, the LinkedIn relationships, and work out who is in market and who is just being polite. I built an intelligence pipeline that knew before I did. The version of me that wrote a quarterly plan a decade ago would not recognise the version that now writes one in an afternoon.
+
+Read Matt Mochary's *The Great CEO Within* and operationalised the parts that fit. Zero inbox. Action management. Tried RAPID with the cofounders. RAPID lost.
+
+Rewrote the SynapseDx site. Started rewriting it again, because the GTM changed and so did I.
+
+Replaced Pixieset and Honeybook for my daughter's photography business in one swoop. Built her an AI partner named Betsy who tells her when the numbers say she can quit her day job, drafts her social, edits her caption sets, watches her inbox.
+
+Wrote this site in the cracks, because the only way I make sense of any of it is in writing.
+
+**Currently impressed by:** how much of a day AI does well.
+
+**Currently failing at:** stopping.
+
+**Currently rereading:** Mochary, when I forget that pace is a feature.

--- a/content/now.mdx
+++ b/content/now.mdx
@@ -1,6 +1,6 @@
 ---
 updated: "2026-05-14"
-currently: "The mother of a married woman"
+currently: "Reader, I held it together."
 accent: "ruby"
 ---
 

--- a/content/now.mdx
+++ b/content/now.mdx
@@ -4,11 +4,11 @@ currently: "The mother of a married woman"
 accent: "ruby"
 ---
 
-Two weeks ago I walked my daughter down the aisle.
+Two weeks ago my daughter got married. The week before, we sat together reading recipes for flower arranging. The nerves had to land somewhere.
 
-Before that — and this is the part nobody warns you about — my husband and my son walked *me* in. My son, in his first fitted suit. My husband on the other arm. The room was already full when I got there. The man I have not been married to in twenty-eight years was at the far end of it. We were polite. Twenty-eight years is a long time to be polite for, and we managed.
+On the day, my husband and my son walked *me* in. My son, in a fitted suit. Thirty years old. Still handsome. My husband on the other arm. The room was already full when I got there. The man I have not been married to in twenty-eight years was at the far end of it. We were polite. Twenty-eight years is a long time to be polite for, and we managed.
 
-Then my daughter. Nearly six feet tall in three-inch heels. A classic gown. Wearing the pearls my husband bought me. The first-look photograph has her now-husband almost on his knees, and the rest of us — bridesmaids, my sister, me — in various states of being unable to keep it together.
+Then my daughter walked in on her father's arm. Nearly six feet tall in three-inch heels. A classic gown. Wearing the pearls my husband bought me. The first-look photograph has her now-husband almost on his knees, and the rest of us — bridesmaids, my sister, me — in various states of being unable to keep it together.
 
 The new in-laws calmed themselves with custom monogrammed drink cozies. I tried not to judge. The day was bright and unreasonable. The dance floor was four of us, to a playlist of nineties club music my daughter had snuck in for me.
 
@@ -24,4 +24,4 @@ The wedding has not yet ended in my head.
 
 **Currently failing at:** stopping. The off-grid week did not, apparently, take.
 
-**Currently rereading:** Simon Jimenez, *The Spear Cuts Through Water*. The polyphonic chorus doing what no single narrator can.
+**Currently reading:** Simon Jimenez, *The Spear Cuts Through Water*. The polyphonic chorus doing what no single narrator can.

--- a/content/now.mdx
+++ b/content/now.mdx
@@ -1,23 +1,27 @@
 ---
-updated: "2026-04-26"
-currently: "Everything everywhere all at once"
-accent: "topaz"
+updated: "2026-05-14"
+currently: "The mother of a married woman"
+accent: "ruby"
 ---
 
-I am doing more things at once than I should be. All of them with AI as the partner I never had.
+Two weeks ago I walked my daughter down the aisle.
 
-Selling for SynapseDx, which does not come naturally to me. AI does the part where you read the news, the financials, the LinkedIn relationships, and work out who is in market and who is just being polite. I built an intelligence pipeline that knew before I did. The version of me that wrote a quarterly plan a decade ago would not recognise the version that now writes one in an afternoon.
+Before that — and this is the part nobody warns you about — my husband and my son walked *me* in. My son, in his first fitted suit. My husband on the other arm. The room was already full when I got there. The man I have not been married to in twenty-eight years was at the far end of it. We were polite. Twenty-eight years is a long time to be polite for, and we managed.
 
-Read Matt Mochary's *The Great CEO Within* and operationalised the parts that fit. Zero inbox. Action management. Tried RAPID with the cofounders. RAPID lost.
+Then my daughter. Nearly six feet tall in three-inch heels. A classic gown. Wearing the pearls my husband bought me. The first-look photograph has her now-husband almost on his knees, and the rest of us — bridesmaids, my sister, me — in various states of being unable to keep it together.
 
-Rewrote the SynapseDx site. Started rewriting it again, because the GTM changed and so did I.
+The new in-laws calmed themselves with custom monogrammed drink cozies. I tried not to judge. The day was bright and unreasonable. The dance floor was four of us, to a playlist of nineties club music my daughter had snuck in for me.
 
-Replaced Pixieset and Honeybook for my daughter's photography business in one swoop. Built her an AI partner named Betsy who tells her when the numbers say she can quit her day job, drafts her social, edits her caption sets, watches her inbox.
+A beautiful and terrifying day. For her. Yes, for her.
 
-Wrote this site in the cracks, because the only way I make sense of any of it is in writing.
+Then a week in Costa Rica with my sister. The Arenal volcano. Dart frogs the colour of warning. The toucans declining to appear. The best massage I have ever had, on a wooden deck, in rain, to the sound of howler monkeys. Came back to find the dishwasher exactly where I left it.
 
-**Currently impressed by:** how much of a day AI does well.
+Back at the desk. The website I had been rewriting kept rewriting itself. The booking flow on it is becoming a small live demonstration — the visitor talks to the bot, the bot calls the calendar, the calendar answers, nobody leaves the page. Building the thing the company tells customers it can build.
 
-**Currently failing at:** stopping.
+The wedding has not yet ended in my head.
 
-**Currently rereading:** Mochary, when I forget that pace is a feature.
+**Currently impressed by:** how cleanly joy and grief can share a venue.
+
+**Currently failing at:** stopping. The off-grid week did not, apparently, take.
+
+**Currently rereading:** Simon Jimenez, *The Spear Cuts Through Water*. The polyphonic chorus doing what no single narrator can.

--- a/src/app/archive/page.tsx
+++ b/src/app/archive/page.tsx
@@ -1,11 +1,15 @@
 import type { Metadata } from 'next';
-import type { Fieldwork } from '@/lib/content/types';
+import Link from 'next/link';
+import { format } from 'date-fns';
+import type { Fieldwork, Now } from '@/lib/content/types';
 import { getFieldworkGroupedByStatus } from '@/lib/content/fieldwork';
+import { listNowArchive } from '@/lib/content/now';
 import { ArchiveSection } from '@/components/ArchiveSection';
 
 export const metadata: Metadata = {
   title: 'Archive',
-  description: 'Retired fieldwork organised by status: still right, evolved, changed my mind.',
+  description:
+    'Retired fieldwork organised by status: still right, evolved, changed my mind. Plus past /now entries.',
 };
 
 function sortForArchive(pieces: Fieldwork[]): Fieldwork[] {
@@ -16,13 +20,53 @@ function sortForArchive(pieces: Fieldwork[]): Fieldwork[] {
   });
 }
 
+const fmtDate = (iso: string) => format(new Date(`${iso}T00:00:00Z`), 'd MMM yyyy');
+
+function NowHistorySection({ entries }: { entries: Now[] }) {
+  return (
+    <section aria-labelledby="archive-now-past-months">
+      <header className="mb-6 border-t border-ink/20 pt-4">
+        <h2
+          id="archive-now-past-months"
+          className="font-mono text-xs uppercase tracking-[0.14em] text-ink/60"
+        >
+          now · past months ({entries.length})
+        </h2>
+      </header>
+      <ul className="space-y-5">
+        {entries.map((entry) => {
+          const { updated, currently } = entry.frontmatter;
+          return (
+            <li key={updated} className="flex flex-col gap-1">
+              <Link
+                href={`/now/${updated}`}
+                className="font-serif text-xl italic leading-snug hover:underline"
+              >
+                {currently}
+              </Link>
+              <p className="font-mono text-xs uppercase tracking-[0.14em] text-ink/60">
+                <time dateTime={updated}>{fmtDate(updated)}</time>
+              </p>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
 export default async function ArchivePage() {
-  const groups = await getFieldworkGroupedByStatus();
+  const [groups, nowHistory] = await Promise.all([
+    getFieldworkGroupedByStatus(),
+    listNowArchive(),
+  ]);
   const stillRight = sortForArchive(groups['retired-still-right']);
   const evolved = sortForArchive(groups['retired-evolved']);
   const changedMyMind = sortForArchive(groups['changed-my-mind']);
 
   const anyRetired = stillRight.length + evolved.length + changedMyMind.length > 0;
+  const anyNowHistory = nowHistory.length > 0;
+  const anything = anyRetired || anyNowHistory;
 
   return (
     <div className="max-w-3xl">
@@ -30,11 +74,11 @@ export default async function ArchivePage() {
         <h1 className="font-serif font-black text-5xl tracking-tight">Archive</h1>
         <p className="mt-3 font-serif text-base text-ink/70 italic leading-relaxed max-w-xl">
           Pieces I&apos;ve retired, evolved past, or changed my mind on — kept on the record so I
-          can&apos;t pretend they didn&apos;t happen.
+          can&apos;t pretend they didn&apos;t happen. Past /now entries live here too.
         </p>
       </header>
 
-      {!anyRetired ? (
+      {!anything ? (
         <p className="font-serif text-lg text-ink/70 italic leading-relaxed max-w-xl">
           Nothing retired yet. Come back when I&apos;ve changed my mind about something — which I
           will.
@@ -65,6 +109,7 @@ export default async function ArchivePage() {
               emptyMessage=""
             />
           ) : null}
+          {anyNowHistory ? <NowHistorySection entries={nowHistory} /> : null}
         </div>
       )}
     </div>

--- a/src/app/now/[date]/page.tsx
+++ b/src/app/now/[date]/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import { NowBlock } from '@/components/NowBlock';
+import { getNowByDate, listNowArchive } from '@/lib/content/now';
+
+interface PageProps {
+  params: Promise<{ date: string }>;
+}
+
+export async function generateStaticParams() {
+  const archive = await listNowArchive();
+  return archive.map((entry) => ({ date: entry.frontmatter.updated }));
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { date } = await params;
+  const entry = await getNowByDate(date);
+  if (!entry) return {};
+  return {
+    title: `Now — ${entry.frontmatter.updated}`,
+    description: entry.frontmatter.currently,
+  };
+}
+
+export default async function ArchivedNowPage({ params }: PageProps) {
+  const { date } = await params;
+  const entry = await getNowByDate(date);
+  if (!entry) notFound();
+
+  return (
+    <div className="max-w-3xl">
+      <p className="mb-6 font-mono text-xs uppercase tracking-[0.14em] text-ink/60">
+        <Link href="/archive" className="underline decoration-ink/30 hover:decoration-ink">
+          ← archive
+        </Link>
+        <span className="mx-2 text-ink/30">·</span>
+        <Link href="/now" className="underline decoration-ink/30 hover:decoration-ink">
+          current /now
+        </Link>
+      </p>
+      <NowBlock now={entry} />
+    </div>
+  );
+}

--- a/src/lib/content/now.ts
+++ b/src/lib/content/now.ts
@@ -1,4 +1,6 @@
 import 'server-only';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 
 import { readMdxFile } from './mdx';
 import { contentPaths, DEFAULT_CONTENT_ROOT } from './paths';
@@ -7,6 +9,9 @@ import { NOW_FRONTMATTER, type Now } from './types';
 interface LoaderOptions {
   contentRoot?: string;
 }
+
+/** Filenames in `content/now-archive/` must match YYYY-MM-DD.mdx. */
+const NOW_ARCHIVE_FILE = /^(\d{4}-\d{2}-\d{2})\.mdx$/;
 
 /**
  * Returns the /now content. Returns null if `content/now.mdx` does not
@@ -26,4 +31,46 @@ export async function getNow(options: LoaderOptions = {}): Promise<Now | null> {
 export async function getCurrentlyLine(options: LoaderOptions = {}): Promise<string | null> {
   const now = await getNow(options);
   return now?.frontmatter.currently ?? null;
+}
+
+/**
+ * Returns past /now entries from `content/now-archive/`, newest first.
+ * Each filename must match YYYY-MM-DD.mdx; the date drives both sort
+ * order and the `/now/[date]` route slug.
+ */
+export async function listNowArchive(options: LoaderOptions = {}): Promise<Now[]> {
+  const { nowArchiveDir } = contentPaths(options.contentRoot ?? DEFAULT_CONTENT_ROOT);
+  let entries: string[];
+  try {
+    entries = await fs.readdir(nowArchiveDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+  const dated = entries
+    .map((name) => NOW_ARCHIVE_FILE.exec(name))
+    .filter((m): m is RegExpExecArray => m !== null)
+    .map((m) => ({ date: m[1], file: path.join(nowArchiveDir, m[0]) }));
+
+  const loaded = await Promise.all(
+    dated.map(async ({ file }) => readMdxFile(file, NOW_FRONTMATTER)),
+  );
+  return loaded.sort((a, b) =>
+    b.frontmatter.updated.localeCompare(a.frontmatter.updated),
+  );
+}
+
+/** Returns a single archived /now by its YYYY-MM-DD date slug. */
+export async function getNowByDate(
+  date: string,
+  options: LoaderOptions = {},
+): Promise<Now | null> {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return null;
+  const { nowArchiveDir } = contentPaths(options.contentRoot ?? DEFAULT_CONTENT_ROOT);
+  try {
+    return await readMdxFile(path.join(nowArchiveDir, `${date}.mdx`), NOW_FRONTMATTER);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
 }

--- a/src/lib/content/paths.ts
+++ b/src/lib/content/paths.ts
@@ -9,6 +9,7 @@ export function contentPaths(root: string = DEFAULT_CONTENT_ROOT) {
     fieldworkDir: path.join(root, 'fieldwork'),
     postcardsDir: path.join(root, 'postcards'),
     nowFile: path.join(root, 'now.mdx'),
+    nowArchiveDir: path.join(root, 'now-archive'),
     tasteFile: path.join(root, 'taste.mdx'),
   };
 }


### PR DESCRIPTION
## Summary

Archive the April /now and replace with a May refresh written from the post-wedding, post-Costa-Rica vantage point. Same /now format (currently / impressed by / failing at / rereading), shifted posture.

## What's in this PR

- `content/now-archive/2026-04-26.mdx` — the previous /now, preserved verbatim under its `updated` date. New `content/now-archive/` directory.
- `content/now.mdx` — new live /now. Accent shifts from topaz to ruby (wedding palette was sunset colours). Currently rereading swaps from Mochary to Jimenez's *The Spear Cuts Through Water* — pace-as-a-feature was the April posture; polyphonic chorus is May's.

The loader at `src/lib/content/now.ts` reads only `content/now.mdx`, so archive files are inert until an archive page is built. No code changes needed.

## Test plan

- [x] `pnpm build` clean
- [x] No real names of people in my life — daughter / son / husband / sister / new in-laws / her now-husband used throughout
- [x] No SynapseDx palette, no corporate-uplift language, no emojis
- [x] Frontmatter shape matches the existing `now.mdx` contract
- [ ] Vercel preview renders correctly at `/now`
- [ ] PR-bot voice pass