### PR TITLE
fix(chat): harden rate-limiter + cut over to Marketplace Upstash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ next-env.d.ts
 .isaac/epics/.current-epic
 .isaac/.telemetry.jsonl
 .isaac/epics/*/progress.yaml
+.env*.local

--- a/src/app/api/chat/__tests__/route.test.ts
+++ b/src/app/api/chat/__tests__/route.test.ts
@@ -47,6 +47,8 @@ const {
   mockMessagesCreate,
   mockAppendArgueLog,
   mockGetFieldworkBySlug,
+  mockGetChatRatelimit,
+  mockGetChatDailyRatelimit,
   afterCallbacks,
   mockAfter,
 } = vi.hoisted(() => {
@@ -56,6 +58,11 @@ const {
     mockMessagesCreate: vi.fn(),
     mockAppendArgueLog: vi.fn(),
     mockGetFieldworkBySlug: vi.fn<(slug: string) => Promise<unknown>>(),
+    // Default: null (no env vars) — the route then skips rate-limiting, which
+    // matches the real module's behaviour when UPSTASH_* are absent. Tests that
+    // exercise the limiter override these per-spec.
+    mockGetChatRatelimit: vi.fn<() => unknown>(() => null),
+    mockGetChatDailyRatelimit: vi.fn<() => unknown>(() => null),
     afterCallbacks,
     mockAfter: vi.fn((cb: () => Promise<void> | void) => {
       afterCallbacks.push(cb);
@@ -92,6 +99,14 @@ vi.mock('@/lib/content/fieldwork', () => ({
   getFieldworkBySlug: mockGetFieldworkBySlug,
 }));
 
+// Rate-limiter — controllable per-test. Default getters return null so the
+// route skips limiting (matches real behaviour with UPSTASH_* unset).
+vi.mock('@/lib/chat/rate-limit', () => ({
+  getChatRatelimit: mockGetChatRatelimit,
+  getChatDailyRatelimit: mockGetChatDailyRatelimit,
+  __resetRatelimitForTests: vi.fn(),
+}));
+
 import { __resetRatelimitForTests } from '@/lib/chat/rate-limit';
 
 const ORIG_KEY = process.env.ANTHROPIC_API_KEY;
@@ -110,6 +125,11 @@ beforeEach(() => {
   mockGetFieldworkBySlug.mockReset();
   // Default: any slug resolves to null (unknown slug — no preface composed).
   mockGetFieldworkBySlug.mockResolvedValue(null);
+  // Default: no limiter configured (matches UPSTASH_* unset). Override per-spec.
+  mockGetChatRatelimit.mockReset();
+  mockGetChatRatelimit.mockReturnValue(null);
+  mockGetChatDailyRatelimit.mockReset();
+  mockGetChatDailyRatelimit.mockReturnValue(null);
   afterCallbacks.length = 0;
   mockAfter.mockClear();
   // Salt is required for all tests except the dedicated "missing salt" one.
@@ -685,6 +705,70 @@ describe('POST /api/chat — from_slug preface (story 003.002)', () => {
     expect(
       errSpy.mock.calls.some((args) =>
         String(args[0] ?? '').includes('piece-preface lookup failed'),
+      ),
+    ).toBe(true);
+    errSpy.mockRestore();
+  });
+});
+
+// Rate-limiter resilience — the store (Upstash) can be idle-disabled or down.
+// A missing/throwing limiter must NEVER take the chat down: fail OPEN.
+describe('POST /api/chat — rate-limiter resilience', () => {
+  beforeEach(() => {
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+  });
+
+  it('still enforces the limit when the store is healthy (429 on baseline)', async () => {
+    mockGetChatRatelimit.mockReturnValue({
+      limit: vi.fn().mockResolvedValue({ success: false }),
+    });
+    const res = await callRoute({
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.category).toBe('rate-limited');
+    expect(mockMessagesStream).not.toHaveBeenCalled();
+  });
+
+  it('fails OPEN (200, no 500) when the baseline limiter throws', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetChatRatelimit.mockReturnValue({
+      limit: vi.fn().mockRejectedValue(new Error('upstash unreachable')),
+    });
+    const res = await callRoute({
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(res.status).toBe(200);
+    await bodyOf(res);
+    // Request proceeded to the model rather than 500ing.
+    expect(mockMessagesStream).toHaveBeenCalledOnce();
+    expect(
+      errSpy.mock.calls.some((args) =>
+        String(args[0] ?? '').includes('baseline ratelimit unavailable'),
+      ),
+    ).toBe(true);
+    errSpy.mockRestore();
+  });
+
+  it('fails OPEN (200, no 500) when the daily limiter throws', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Baseline healthy + under limit; daily store is down.
+    mockGetChatRatelimit.mockReturnValue({
+      limit: vi.fn().mockResolvedValue({ success: true }),
+    });
+    mockGetChatDailyRatelimit.mockReturnValue({
+      limit: vi.fn().mockRejectedValue(new Error('upstash unreachable')),
+    });
+    const res = await callRoute({
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(res.status).toBe(200);
+    await bodyOf(res);
+    expect(mockMessagesStream).toHaveBeenCalledOnce();
+    expect(
+      errSpy.mock.calls.some((args) =>
+        String(args[0] ?? '').includes('daily ratelimit unavailable'),
       ),
     ).toBe(true);
     errSpy.mockRestore();

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -90,27 +90,38 @@ export async function POST(req: Request) {
 
   const ip = getIp(req);
 
-  // 3. Rate-limit: baseline (10 / 10 min) + hard cap (50 / day)
+  // 3. Rate-limit: baseline (10 / 10 min) + hard cap (50 / day).
+  // Fail OPEN if the store is unreachable (e.g. Upstash idle-disabled or
+  // down): a missing rate-limiter must never take the chat down. We'd rather
+  // briefly forgo abuse protection than 500 every request.
   const baseline = getChatRatelimit();
   if (baseline) {
-    const { success } = await baseline.limit(ip);
-    if (!success) {
-      return errorResponse(
-        429,
-        "ease up — we've had a lot of arguing today",
-        'rate-limited',
-      );
+    try {
+      const { success } = await baseline.limit(ip);
+      if (!success) {
+        return errorResponse(
+          429,
+          "ease up — we've had a lot of arguing today",
+          'rate-limited',
+        );
+      }
+    } catch (err) {
+      console.error('[chat] baseline ratelimit unavailable, failing open', err);
     }
   }
   const daily = getChatDailyRatelimit();
   if (daily) {
-    const { success } = await daily.limit(`day:${ip}`);
-    if (!success) {
-      return errorResponse(
-        429,
-        "that's your 50 for today. come back tomorrow",
-        'rate-limited',
-      );
+    try {
+      const { success } = await daily.limit(`day:${ip}`);
+      if (!success) {
+        return errorResponse(
+          429,
+          "that's your 50 for today. come back tomorrow",
+          'rate-limited',
+        );
+      }
+    } catch (err) {
+      console.error('[chat] daily ratelimit unavailable, failing open', err);
     }
   }
 

--- a/src/lib/chat/__tests__/rate-limit.test.ts
+++ b/src/lib/chat/__tests__/rate-limit.test.ts
@@ -4,25 +4,42 @@ import { __resetRatelimitForTests, getChatRatelimit, getChatDailyRatelimit } fro
 
 const ORIG_URL = process.env.UPSTASH_REDIS_REST_URL;
 const ORIG_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
+const ORIG_KV_URL = process.env.KV_REST_API_URL;
+const ORIG_KV_TOKEN = process.env.KV_REST_API_TOKEN;
+
+function restore(name: string, orig: string | undefined) {
+  if (orig === undefined) delete process.env[name];
+  else process.env[name] = orig;
+}
 
 beforeEach(() => {
   __resetRatelimitForTests();
+  // Start each test from a known-clean credential state.
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  delete process.env.KV_REST_API_URL;
+  delete process.env.KV_REST_API_TOKEN;
 });
 
 afterEach(() => {
   __resetRatelimitForTests();
-  if (ORIG_URL === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
-  else process.env.UPSTASH_REDIS_REST_URL = ORIG_URL;
-  if (ORIG_TOKEN === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
-  else process.env.UPSTASH_REDIS_REST_TOKEN = ORIG_TOKEN;
+  restore('UPSTASH_REDIS_REST_URL', ORIG_URL);
+  restore('UPSTASH_REDIS_REST_TOKEN', ORIG_TOKEN);
+  restore('KV_REST_API_URL', ORIG_KV_URL);
+  restore('KV_REST_API_TOKEN', ORIG_KV_TOKEN);
 });
 
 describe('getChatRatelimit', () => {
   it('returns null when env vars are absent', () => {
-    delete process.env.UPSTASH_REDIS_REST_URL;
-    delete process.env.UPSTASH_REDIS_REST_TOKEN;
     expect(getChatRatelimit()).toBeNull();
     expect(getChatDailyRatelimit()).toBeNull();
+  });
+
+  it('builds a limiter from the Marketplace KV_REST_API_* vars', () => {
+    process.env.KV_REST_API_URL = 'https://example.upstash.io';
+    process.env.KV_REST_API_TOKEN = 'kv-token';
+    expect(getChatRatelimit()).not.toBeNull();
+    expect(getChatDailyRatelimit()).not.toBeNull();
   });
 
   it('returns a Ratelimit instance when env vars are present', () => {

--- a/src/lib/chat/rate-limit.ts
+++ b/src/lib/chat/rate-limit.ts
@@ -7,9 +7,10 @@ import { Redis } from '@upstash/redis';
  *   - Baseline: 10 messages / 10 min / IP (AC-003)
  *   - Hard cap: 50 messages / day / IP
  *
- * Both return `null` when UPSTASH_REDIS_REST_URL/TOKEN env vars are absent —
- * in that case the route is permissive (dev/CI). Production MUST set these;
- * Vercel env config happens in 001.016.
+ * Both return `null` when no Redis credentials are present in the env — in
+ * that case the route is permissive (dev/CI). Production gets these from the
+ * Vercel Marketplace Upstash integration (KV_REST_API_URL/TOKEN), with the
+ * legacy manually-set UPSTASH_REDIS_REST_URL/TOKEN kept as a fallback.
  *
  * The numeric thresholds are env-tunable so previews can run a generous
  * limit for QA without burning the production posture:
@@ -30,8 +31,12 @@ let _baseline: Ratelimit | null = null;
 let _daily: Ratelimit | null = null;
 
 function getRedisFromEnv(): Redis | null {
-  const url = process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  // Prefer the Vercel Marketplace Upstash integration vars (KV_REST_API_*);
+  // fall back to the legacy manually-set UPSTASH_REDIS_REST_* vars so the
+  // limiter keeps working during the cutover (and in any env still on them).
+  const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
+  const token =
+    process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
   if (!url || !token) return null;
   return new Redis({ url, token });
 }


### PR DESCRIPTION
## Why

Upstash flagged the bines.ai Redis DB for idle-disable due to low chat traffic. Investigation found the DB was wired via **manual `UPSTASH_*` env vars** (no Vercel billing relationship) rather than the Vercel Marketplace integration — which is why it idles out. While there, found the rate-limiter could take the whole chat down if the store ever disappeared.

## What changed

**1. Fail OPEN on store failure** (`src/app/api/chat/route.ts`)
The `.limit()` calls were unguarded. With env vars set but the store gone (idle-disabled or down), every call would throw and 500 the chat. Now wrapped in `try/catch` — log and proceed. We'd rather briefly forgo abuse protection than break the chat.

**2. Cut over to the Marketplace Upstash store** (`src/lib/chat/rate-limit.ts`)
Provisioned `upstash-kv-yellow-pocket` via the Vercel Marketplace (free plan) and connected it to the project. It injects `KV_REST_API_URL` / `KV_REST_API_TOKEN`. Code now reads those first, falling back to the legacy `UPSTASH_REDIS_REST_*` vars so nothing breaks mid-cutover. New store verified reachable (`PONG`).

## Tests
- Route-level: baseline/daily limiter throwing → 200 (not 500); 429 still enforced when healthy.
- Unit: limiter builds from `KV_REST_API_*` vars.
- `pnpm typecheck && pnpm lint && pnpm test` → green, **599 tests pass**.
- `/security-review` run on the branch → clean.

## Follow-up (manual, after merge)
- [ ] Delete the old standalone DB in the Upstash console (the idle-disabling one) once chat is confirmed working on the new store.
- [ ] Optional later cleanup: remove the legacy `UPSTASH_REDIS_REST_*` Vercel env vars (kept as fallback for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)