### PR TITLE
fix(gallery): visible scroll controls + fit panels to viewport

### DIFF
--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -17,13 +17,5 @@ export const metadata: Metadata = {
 
 export default async function GalleryPage() {
   const pieces = await getGalleryFieldwork();
-  return (
-    <div className="space-y-8">
-      <header className="mb-4">
-        <h1 className="font-serif font-black text-4xl sm:text-5xl tracking-tight">Gallery</h1>
-        <p className="mt-3 font-serif text-base text-ink/70 italic">{DESCRIPTION}</p>
-      </header>
-      <Gallery pieces={pieces} />
-    </div>
-  );
+  return <Gallery pieces={pieces} description={DESCRIPTION} />;
 }

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,73 +1,148 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Fieldwork } from '@/lib/content/types';
 import { GalleryPanel } from './GalleryPanel';
 
 interface GalleryProps {
   pieces: Fieldwork[];
+  description: string;
 }
 
 /**
- * The gallery's scroll container. Horizontal scroll-snap of one panel per
- * Fieldwork piece. Listens for ArrowLeft / ArrowRight when focused and
- * scrolls one panel-width in that direction. Includes a quiet `← →` glyph
- * at the top-right of the container as a discoverability affordance for
- * non-touch desktop visitors.
+ * The gallery's scroll container plus its header controls. Panels are
+ * full-bleed (100vw × 100dvh) horizontal scroll-snap, one per Fieldwork
+ * piece. The prev / next buttons live in the header — on paper, beside the
+ * title — deliberately NOT over the artwork. They're the discoverability
+ * affordance for mouse-only desktop visitors, who have no swipe gesture and
+ * whose vertical wheel doesn't move a horizontal container.
  *
- * Renders empty state when no pieces in scope (shouldn't happen in prod
- * with current content, but keeps the page graceful during transitions).
+ * Each button is disabled (dimmed, inert) when there's nothing more to
+ * scroll in that direction, so the toolbar stays put rather than shifting.
+ * ArrowLeft / ArrowRight still scroll one panel-width when the panel region
+ * is focused.
  */
-export function Gallery({ pieces }: GalleryProps) {
+export function Gallery({ pieces, description }: GalleryProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  // Recompute which directions still have content to reveal. A small
+  // threshold absorbs sub-pixel rounding at the snap points.
+  const syncScrollState = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const max = el.scrollWidth - el.clientWidth;
+    setCanScrollLeft(el.scrollLeft > 8);
+    setCanScrollRight(el.scrollLeft < max - 8);
+  }, []);
+
+  const scrollByPanel = useCallback((direction: 1 | -1) => {
+    const el = containerRef.current;
+    if (!el) return;
+    el.scrollBy({ left: direction * el.clientWidth, behavior: 'smooth' });
+  }, []);
+
+  // Size the panel strip to the viewport height that's left below the page
+  // chrome (site nav + this gallery header), so a full panel — caption and
+  // all — fits on screen instead of spilling past the fold. A plain 100dvh
+  // panel overflows by exactly the height of everything stacked above it.
+  const sizeStrip = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const topOffset = el.getBoundingClientRect().top + window.scrollY;
+    el.style.height = `${Math.max(360, window.innerHeight - topOffset)}px`;
+  }, []);
 
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
+
+    syncScrollState();
+    sizeStrip();
+
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
       event.preventDefault();
-      const direction = event.key === 'ArrowRight' ? 1 : -1;
-      el.scrollBy({ left: direction * el.clientWidth, behavior: 'smooth' });
+      scrollByPanel(event.key === 'ArrowRight' ? 1 : -1);
     };
-    el.addEventListener('keydown', onKeyDown);
-    return () => el.removeEventListener('keydown', onKeyDown);
-  }, []);
 
-  if (pieces.length === 0) {
-    return (
-      <p className="font-serif text-base text-ink/60 italic leading-relaxed">
-        Nothing in the gallery yet — come back when there&apos;s more to look at.
-      </p>
-    );
-  }
+    const onResize = () => {
+      sizeStrip();
+      syncScrollState();
+    };
+
+    el.addEventListener('keydown', onKeyDown);
+    el.addEventListener('scroll', syncScrollState, { passive: true });
+    window.addEventListener('resize', onResize);
+    return () => {
+      el.removeEventListener('keydown', onKeyDown);
+      el.removeEventListener('scroll', syncScrollState);
+      window.removeEventListener('resize', onResize);
+    };
+  }, [scrollByPanel, sizeStrip, syncScrollState]);
+
+  const buttonClass =
+    'grid h-11 w-11 place-items-center rounded-full border border-ink/15 bg-paper font-mono text-base text-ink transition-opacity duration-150 hover:border-ink/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ink disabled:pointer-events-none disabled:opacity-25';
 
   return (
-    <section
-      ref={containerRef}
-      role="region"
-      aria-label="Fieldwork gallery, horizontal scroll"
-      tabIndex={0}
-      data-testid="gallery"
-      className="relative w-screen left-1/2 -translate-x-1/2 flex overflow-x-auto snap-x snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden focus-visible:outline-none"
-      style={{ scrollSnapType: 'x mandatory' }}
-    >
-      {pieces.map((piece, index) => (
-        <GalleryPanel
-          key={piece.frontmatter.slug}
-          piece={piece}
-          priority={index === 0}
-        />
-      ))}
+    <div className="space-y-8">
+      <header className="mb-4 flex items-end justify-between gap-6">
+        <div>
+          <h1 className="font-serif font-black text-4xl sm:text-5xl tracking-tight">
+            Gallery
+          </h1>
+          <p className="mt-3 font-serif text-base text-ink/70 italic">{description}</p>
+        </div>
+        {pieces.length > 0 ? (
+          <div className="flex shrink-0 gap-2" aria-label="Gallery navigation">
+            <button
+              type="button"
+              data-testid="gallery-prev"
+              aria-label="Previous panel"
+              disabled={!canScrollLeft}
+              onClick={() => scrollByPanel(-1)}
+              className={buttonClass}
+            >
+              <span aria-hidden="true">←</span>
+            </button>
+            <button
+              type="button"
+              data-testid="gallery-next"
+              aria-label="Next panel"
+              disabled={!canScrollRight}
+              onClick={() => scrollByPanel(1)}
+              className={buttonClass}
+            >
+              <span aria-hidden="true">→</span>
+            </button>
+          </div>
+        ) : null}
+      </header>
 
-      {/* Scroll affordance glyph — quiet, top-right of the container. */}
-      <div
-        data-testid="gallery-affordance"
-        aria-hidden="true"
-        className="pointer-events-none fixed top-6 right-6 z-10 font-mono text-xs uppercase tracking-[0.14em] text-ink/30 mix-blend-multiply"
-      >
-        ← →
-      </div>
-    </section>
+      {pieces.length === 0 ? (
+        <p className="font-serif text-base text-ink/60 italic leading-relaxed">
+          Nothing in the gallery yet — come back when there&apos;s more to look at.
+        </p>
+      ) : (
+        <section
+          ref={containerRef}
+          role="region"
+          aria-label="Fieldwork gallery, horizontal scroll"
+          tabIndex={0}
+          data-testid="gallery"
+          className="relative w-screen left-1/2 -translate-x-1/2 flex overflow-x-auto snap-x snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden focus-visible:outline-none"
+          style={{ scrollSnapType: 'x mandatory' }}
+        >
+          {pieces.map((piece, index) => (
+            <GalleryPanel
+              key={piece.frontmatter.slug}
+              piece={piece}
+              priority={index === 0}
+            />
+          ))}
+        </section>
+      )}
+    </div>
   );
 }

--- a/src/components/GalleryPanel.tsx
+++ b/src/components/GalleryPanel.tsx
@@ -42,7 +42,7 @@ export function GalleryPanel({ piece, priority }: GalleryPanelProps) {
     <article
       data-testid="gallery-panel"
       data-slug={slug}
-      className="relative w-screen h-[100dvh] shrink-0 snap-center"
+      className="relative w-screen h-full shrink-0 snap-center"
       style={{ ['--color-accent' as string]: accentVar(accent) } as React.CSSProperties}
     >
       <Link

--- a/src/components/VideoLoop.tsx
+++ b/src/components/VideoLoop.tsx
@@ -154,8 +154,6 @@ export function VideoLoop({
         src={hasBeenInView ? src : undefined}
         poster={poster}
         preload={priority ? 'auto' : 'metadata'}
-        // @ts-expect-error fetchpriority is a valid HTML attr; React types lag
-        fetchpriority={priority ? 'high' : undefined}
         muted
         loop
         playsInline

--- a/src/components/__tests__/Gallery.test.tsx
+++ b/src/components/__tests__/Gallery.test.tsx
@@ -45,14 +45,29 @@ function makePiece(slug: string, title: string): Fieldwork {
   };
 }
 
+function renderGallery(pieces: Fieldwork[]) {
+  return render(<Gallery pieces={pieces} description="Atmospheric loops." />);
+}
+
+// Drive the container's scroll geometry, then fire a scroll event so the
+// component recomputes which directions are still scrollable.
+function setScroll(
+  region: HTMLElement,
+  { scrollLeft, clientWidth, scrollWidth }: { scrollLeft: number; clientWidth: number; scrollWidth: number },
+) {
+  Object.defineProperty(region, 'scrollLeft', { value: scrollLeft, configurable: true });
+  Object.defineProperty(region, 'clientWidth', { value: clientWidth, configurable: true });
+  Object.defineProperty(region, 'scrollWidth', { value: scrollWidth, configurable: true });
+  fireEvent.scroll(region);
+}
+
 describe('<Gallery>', () => {
   it('renders one panel per piece in the given order', () => {
-    const pieces = [
+    renderGallery([
       makePiece('a', 'Alpha'),
       makePiece('b', 'Beta'),
       makePiece('c', 'Gamma'),
-    ];
-    render(<Gallery pieces={pieces} />);
+    ]);
     const panels = screen.getAllByTestId('gallery-panel');
     expect(panels).toHaveLength(3);
     expect(panels[0]).toHaveAttribute('data-slug', 'a');
@@ -61,33 +76,76 @@ describe('<Gallery>', () => {
   });
 
   it('passes priority=true only to the first panel', () => {
-    render(
-      <Gallery
-        pieces={[makePiece('a', 'A'), makePiece('b', 'B'), makePiece('c', 'C')]}
-      />,
-    );
+    renderGallery([makePiece('a', 'A'), makePiece('b', 'B'), makePiece('c', 'C')]);
     const panels = screen.getAllByTestId('gallery-panel');
     expect(panels[0]).toHaveAttribute('data-priority', '1');
     expect(panels[1]).toHaveAttribute('data-priority', '0');
     expect(panels[2]).toHaveAttribute('data-priority', '0');
   });
 
-  it('renders the scroll affordance glyph', () => {
-    render(<Gallery pieces={[makePiece('a', 'A')]} />);
-    const affordance = screen.getByTestId('gallery-affordance');
-    expect(affordance.textContent).toContain('←');
-    expect(affordance.textContent).toContain('→');
+  it('renders the gallery header with the title and description', () => {
+    renderGallery([makePiece('a', 'A')]);
+    expect(screen.getByRole('heading', { name: 'Gallery' })).toBeInTheDocument();
+    expect(screen.getByText('Atmospheric loops.')).toBeInTheDocument();
   });
 
-  it('renders empty-state copy when pieces is empty', () => {
-    render(<Gallery pieces={[]} />);
-    expect(
-      screen.getByText(/nothing in the gallery yet/i),
-    ).toBeInTheDocument();
+  it('renders labelled prev / next scroll buttons', () => {
+    renderGallery([makePiece('a', 'A'), makePiece('b', 'B')]);
+    expect(screen.getByTestId('gallery-prev')).toHaveAttribute('aria-label', 'Previous panel');
+    expect(screen.getByTestId('gallery-next')).toHaveAttribute('aria-label', 'Next panel');
+  });
+
+  it('clicking the next button scrolls one panel-width forward', () => {
+    renderGallery([makePiece('a', 'A'), makePiece('b', 'B')]);
+    const region = screen.getByTestId('gallery');
+    const scrollBySpy = vi.fn();
+    Object.defineProperty(region, 'scrollBy', { value: scrollBySpy, configurable: true });
+    // Enable the next button: there is content to the right.
+    setScroll(region, { scrollLeft: 0, clientWidth: 1024, scrollWidth: 2048 });
+    fireEvent.click(screen.getByTestId('gallery-next'));
+    expect(scrollBySpy).toHaveBeenCalledWith({ left: 1024, behavior: 'smooth' });
+  });
+
+  it('clicking the prev button scrolls one panel-width backward', () => {
+    renderGallery([makePiece('a', 'A'), makePiece('b', 'B')]);
+    const region = screen.getByTestId('gallery');
+    const scrollBySpy = vi.fn();
+    Object.defineProperty(region, 'scrollBy', { value: scrollBySpy, configurable: true });
+    // Enable the prev button: we're scrolled away from the start.
+    setScroll(region, { scrollLeft: 800, clientWidth: 800, scrollWidth: 2400 });
+    fireEvent.click(screen.getByTestId('gallery-prev'));
+    expect(scrollBySpy).toHaveBeenCalledWith({ left: -800, behavior: 'smooth' });
+  });
+
+  it('disables the prev button at the start and enables it once scrolled', () => {
+    renderGallery([makePiece('a', 'A'), makePiece('b', 'B')]);
+    const region = screen.getByTestId('gallery');
+    const prev = screen.getByTestId('gallery-prev');
+    // At the start (scrollLeft 0) the prev button is inert.
+    expect(prev).toBeDisabled();
+
+    setScroll(region, { scrollLeft: 500, clientWidth: 1000, scrollWidth: 2000 });
+    expect(prev).toBeEnabled();
+  });
+
+  it('disables the next button once scrolled to the end', () => {
+    renderGallery([makePiece('a', 'A'), makePiece('b', 'B')]);
+    const region = screen.getByTestId('gallery');
+    const next = screen.getByTestId('gallery-next');
+    // Scrolled fully right: scrollLeft === scrollWidth - clientWidth.
+    setScroll(region, { scrollLeft: 1000, clientWidth: 1000, scrollWidth: 2000 });
+    expect(next).toBeDisabled();
+  });
+
+  it('renders empty-state copy (and no nav buttons) when pieces is empty', () => {
+    renderGallery([]);
+    expect(screen.getByText(/nothing in the gallery yet/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('gallery-prev')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('gallery-next')).not.toBeInTheDocument();
   });
 
   it('container has region semantics and tabIndex=0 for keyboard focus', () => {
-    render(<Gallery pieces={[makePiece('a', 'A')]} />);
+    renderGallery([makePiece('a', 'A')]);
     const region = screen.getByTestId('gallery');
     expect(region).toHaveAttribute('role', 'region');
     expect(region).toHaveAttribute('aria-label', 'Fieldwork gallery, horizontal scroll');
@@ -95,9 +153,7 @@ describe('<Gallery>', () => {
   });
 
   it('ArrowRight key on the container calls scrollBy with positive clientWidth', () => {
-    render(
-      <Gallery pieces={[makePiece('a', 'A'), makePiece('b', 'B')]} />,
-    );
+    renderGallery([makePiece('a', 'A'), makePiece('b', 'B')]);
     const region = screen.getByTestId('gallery');
     const scrollBySpy = vi.fn();
     Object.defineProperty(region, 'scrollBy', { value: scrollBySpy, configurable: true });
@@ -107,9 +163,7 @@ describe('<Gallery>', () => {
   });
 
   it('ArrowLeft key on the container calls scrollBy with negative clientWidth', () => {
-    render(
-      <Gallery pieces={[makePiece('a', 'A'), makePiece('b', 'B')]} />,
-    );
+    renderGallery([makePiece('a', 'A'), makePiece('b', 'B')]);
     const region = screen.getByTestId('gallery');
     const scrollBySpy = vi.fn();
     Object.defineProperty(region, 'scrollBy', { value: scrollBySpy, configurable: true });
@@ -119,9 +173,7 @@ describe('<Gallery>', () => {
   });
 
   it('does not call scrollBy for non-arrow keys', () => {
-    render(
-      <Gallery pieces={[makePiece('a', 'A'), makePiece('b', 'B')]} />,
-    );
+    renderGallery([makePiece('a', 'A'), makePiece('b', 'B')]);
     const region = screen.getByTestId('gallery');
     const scrollBySpy = vi.fn();
     Object.defineProperty(region, 'scrollBy', { value: scrollBySpy, configurable: true });


### PR DESCRIPTION
## Problem

The horizontal scroll-snap gallery had no usable affordance for **mouse-only desktop** visitors — no swipe gesture, and a vertical mouse wheel doesn't move a horizontal container. Two follow-on issues surfaced while fixing it: buttons placed inside the transformed scroll container rode off-screen, and panels were cut off in laptop full-screen.

## Changes

- **Prev/next buttons** in the gallery header (on paper, beside the title — never over the artwork), scrolling one panel-width. They disable + dim at each end. Keyboard `ArrowLeft`/`Right` still work.
- **Controls rendered outside the transformed `<section>`.** A `transform` ancestor reanchors `position: fixed` to that element, so controls placed inside rode the scroll off-screen. Lifted the visible header into the `Gallery` client component so buttons + scroll container share state.
- **Panel strip sized to the remaining viewport height** below the page chrome instead of a fixed `100dvh`, which overflowed by the nav + header height and cut off each panel's bottom caption in laptop full-screen. Recomputed on resize.
- **Removed invalid lowercase `fetchpriority`** attr on `<video>` in `VideoLoop` (not a valid video attribute; triggered a React DOM-property console error). `preload` already handles video fetch priority.

## Verification

- typecheck ✅ · lint ✅ · **604 tests** ✅ · build ✅
- Live-checked: buttons on paper above the art, prev disabled at start / next disabled at end, click advances panels, full panel + caption fits at 1280×800 and 1440×700, console error gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)