### PR TITLE
fix(gallery): scroll arrows bricked after letterbox change

### DIFF
--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -17,8 +17,12 @@ interface GalleryProps {
  * affordance for mouse-only desktop visitors, who have no swipe gesture and
  * whose vertical wheel doesn't move a horizontal container.
  *
- * Each button is disabled (dimmed, inert) when there's nothing more to
- * scroll in that direction, so the toolbar stays put rather than shifting.
+ * Each button is dimmed (aria-disabled) when there's nothing more to
+ * scroll in that direction, but never actually disabled: a click always
+ * fires and the browser clamps the scroll at the ends. The dimming is
+ * cosmetic and self-heals on the first scroll event — a stale mount-time
+ * read must never be able to brick the controls (it did once: the
+ * size-contained panels land their layout after the first state read).
  * ArrowLeft / ArrowRight still scroll one panel-width when the panel region
  * is focused.
  */
@@ -27,63 +31,117 @@ export function Gallery({ pieces, description }: GalleryProps) {
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
 
+  // Resolve the LIVE scroll container at call time. Streaming hydration can
+  // replace the section's DOM node after mount, leaving `containerRef`
+  // pointing at a detached copy — scrolls on it move nothing and its
+  // zero scrollWidth reads as "nothing to scroll", which bricked the
+  // arrows. Never trust the ref blindly: fall back to the document when
+  // the referenced node is no longer connected.
+  const liveContainer = useCallback((): HTMLElement | null => {
+    const el = containerRef.current;
+    if (el && el.isConnected) return el;
+    return document.querySelector<HTMLElement>('[data-testid="gallery"]');
+  }, []);
+
   // Recompute which directions still have content to reveal. A small
   // threshold absorbs sub-pixel rounding at the snap points.
   const syncScrollState = useCallback(() => {
-    const el = containerRef.current;
+    const el = liveContainer();
     if (!el) return;
     const max = el.scrollWidth - el.clientWidth;
     setCanScrollLeft(el.scrollLeft > 8);
     setCanScrollRight(el.scrollLeft < max - 8);
-  }, []);
+  }, [liveContainer]);
 
-  const scrollByPanel = useCallback((direction: 1 | -1) => {
-    const el = containerRef.current;
-    if (!el) return;
-    el.scrollBy({ left: direction * el.clientWidth, behavior: 'smooth' });
-  }, []);
+  const scrollByPanel = useCallback(
+    (direction: 1 | -1) => {
+      const el = liveContainer();
+      if (!el) return;
+      el.scrollBy({ left: direction * el.clientWidth, behavior: 'smooth' });
+    },
+    [liveContainer],
+  );
 
   // Size the panel strip to the viewport height that's left below the page
   // chrome (site nav + this gallery header), so a full panel — caption and
   // all — fits on screen instead of spilling past the fold. A plain 100dvh
   // panel overflows by exactly the height of everything stacked above it.
   const sizeStrip = useCallback(() => {
-    const el = containerRef.current;
+    const el = liveContainer();
     if (!el) return;
     const topOffset = el.getBoundingClientRect().top + window.scrollY;
     el.style.height = `${Math.max(360, window.innerHeight - topOffset)}px`;
-  }, []);
+  }, [liveContainer]);
 
   useEffect(() => {
-    const el = containerRef.current;
+    const el = liveContainer();
     if (!el) return;
 
-    syncScrollState();
+    // Order matters: the strip must have its real height before the
+    // scroll-state read — size-contained panels report no scrollable
+    // overflow while the strip is collapsed, which left both buttons
+    // permanently disabled when this read ran first.
     sizeStrip();
+    syncScrollState();
 
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
-      event.preventDefault();
-      scrollByPanel(event.key === 'ArrowRight' ? 1 : -1);
-    };
+    // The size-contained panels settle their layout after first paint
+    // (fonts, the JS-set strip height, video posters), and a single
+    // mount-time read can land before the container reports its true
+    // scrollWidth. Re-measure on a short settle schedule; reads are
+    // cheap and idempotent.
+    const settleTimers = [0, 250, 1000].map((ms) =>
+      window.setTimeout(() => {
+        sizeStrip();
+        syncScrollState();
+      }, ms),
+    );
 
     const onResize = () => {
       sizeStrip();
       syncScrollState();
     };
 
-    el.addEventListener('keydown', onKeyDown);
-    el.addEventListener('scroll', syncScrollState, { passive: true });
+    // Scroll events don't bubble, but they ARE observable on window in the
+    // capture phase. Listening there (instead of on `el`) survives the
+    // container node being swapped out from under us by hydration.
+    const onAnyScroll = (event: Event) => {
+      const target = event.target as HTMLElement | null;
+      if (target?.dataset?.testid === 'gallery') syncScrollState();
+    };
+
+    // Belt and braces: re-read whenever the container's box actually
+    // changes (font swaps, chrome above the strip settling, etc.) —
+    // window resize alone misses layout shifts that happen after mount.
+    // Observing document.body too keeps this working even if `el` is the
+    // node that got swapped.
+    const observer =
+      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(onResize) : null;
+    observer?.observe(el);
+    if (document.body) observer?.observe(document.body);
+
+    window.addEventListener('scroll', onAnyScroll, { capture: true, passive: true });
     window.addEventListener('resize', onResize);
     return () => {
-      el.removeEventListener('keydown', onKeyDown);
-      el.removeEventListener('scroll', syncScrollState);
+      settleTimers.forEach((t) => window.clearTimeout(t));
+      observer?.disconnect();
+      window.removeEventListener('scroll', onAnyScroll, { capture: true });
       window.removeEventListener('resize', onResize);
     };
-  }, [scrollByPanel, sizeStrip, syncScrollState]);
+  }, [liveContainer, scrollByPanel, sizeStrip, syncScrollState]);
+
+  // Keyboard support lives on the element via React (not a manual
+  // listener), so it always rides whichever DOM node React currently owns.
+  const onContainerKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+      event.preventDefault();
+      scrollByPanel(event.key === 'ArrowRight' ? 1 : -1);
+    },
+    [scrollByPanel],
+  );
 
   const buttonClass =
-    'grid h-11 w-11 place-items-center rounded-full border border-ink/15 bg-paper font-mono text-base text-ink transition-opacity duration-150 hover:border-ink/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ink disabled:pointer-events-none disabled:opacity-25';
+    'grid h-11 w-11 place-items-center rounded-full border border-ink/15 bg-paper font-mono text-base text-ink transition-opacity duration-150 hover:border-ink/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ink aria-disabled:opacity-25';
 
   return (
     <div className="space-y-8">
@@ -100,7 +158,7 @@ export function Gallery({ pieces, description }: GalleryProps) {
               type="button"
               data-testid="gallery-prev"
               aria-label="Previous panel"
-              disabled={!canScrollLeft}
+              aria-disabled={!canScrollLeft}
               onClick={() => scrollByPanel(-1)}
               className={buttonClass}
             >
@@ -110,7 +168,7 @@ export function Gallery({ pieces, description }: GalleryProps) {
               type="button"
               data-testid="gallery-next"
               aria-label="Next panel"
-              disabled={!canScrollRight}
+              aria-disabled={!canScrollRight}
               onClick={() => scrollByPanel(1)}
               className={buttonClass}
             >
@@ -130,6 +188,7 @@ export function Gallery({ pieces, description }: GalleryProps) {
           role="region"
           aria-label="Fieldwork gallery, horizontal scroll"
           tabIndex={0}
+          onKeyDown={onContainerKeyDown}
           data-testid="gallery"
           className="relative w-screen left-1/2 -translate-x-1/2 flex overflow-x-auto snap-x snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden focus-visible:outline-none"
           style={{ scrollSnapType: 'x mandatory' }}

--- a/src/components/__tests__/Gallery.test.tsx
+++ b/src/components/__tests__/Gallery.test.tsx
@@ -117,24 +117,27 @@ describe('<Gallery>', () => {
     expect(scrollBySpy).toHaveBeenCalledWith({ left: -800, behavior: 'smooth' });
   });
 
-  it('disables the prev button at the start and enables it once scrolled', () => {
+  it('dims (aria-disabled) the prev button at the start and undims it once scrolled', () => {
     renderGallery([makePiece('a', 'A'), makePiece('b', 'B')]);
     const region = screen.getByTestId('gallery');
     const prev = screen.getByTestId('gallery-prev');
-    // At the start (scrollLeft 0) the prev button is inert.
-    expect(prev).toBeDisabled();
+    // At the start (scrollLeft 0) the prev button is dimmed but NEVER
+    // disabled — a stale mount-time read must not brick the control.
+    expect(prev).toHaveAttribute('aria-disabled', 'true');
+    expect(prev).toBeEnabled();
 
     setScroll(region, { scrollLeft: 500, clientWidth: 1000, scrollWidth: 2000 });
-    expect(prev).toBeEnabled();
+    expect(prev).toHaveAttribute('aria-disabled', 'false');
   });
 
-  it('disables the next button once scrolled to the end', () => {
+  it('dims (aria-disabled) the next button once scrolled to the end — but it stays clickable', () => {
     renderGallery([makePiece('a', 'A'), makePiece('b', 'B')]);
     const region = screen.getByTestId('gallery');
     const next = screen.getByTestId('gallery-next');
     // Scrolled fully right: scrollLeft === scrollWidth - clientWidth.
     setScroll(region, { scrollLeft: 1000, clientWidth: 1000, scrollWidth: 2000 });
-    expect(next).toBeDisabled();
+    expect(next).toHaveAttribute('aria-disabled', 'true');
+    expect(next).toBeEnabled();
   });
 
   it('renders empty-state copy (and no nav buttons) when pieces is empty', () => {


### PR DESCRIPTION
Maria's report: arrows dead on /gallery after #53.

**Root cause:** the letterbox change made the strip's layout settle later, and the mount-time scroll-state read latched both buttons `disabled` with nothing to re-trigger it.

**Fix (layered):** never-disabled buttons (dim via `aria-disabled`, clicks always fire, browser clamps at the ends) · sizeStrip-before-read + settle timers + ResizeObserver · live-container resolution at call time (hydration-strand-proof) · window-capture scroll sync · React-managed keydown.

Tests updated to the new contract. Verified on the production build headless: correct initial dim, 0→1200→2400→1200 walk with dim tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)