### PR TITLE
fix(fw04): de-duplicate the pull-quote line

### DIFF
--- a/content/fieldwork/04-singularity-different-clothes.mdx
+++ b/content/fieldwork/04-singularity-different-clothes.mdx
@@ -28,7 +28,7 @@ I would not flip on the timeline either. Kurzweil's curve, eight years on, is st
 
 What I would flip on is the *shape.*
 
-I was picturing a Kurzweil-style fusion. Implants. Bionic ascendance. *Neuromancer.* What we got is quieter and weirder: psychological codependency. We are not merging with machines via wires. We are merging with them via attention.
+I was picturing a Kurzweil-style fusion. Implants. Bionic ascendance. *Neuromancer.* What we got is quieter and weirder: psychological codependency.
 
 <PullQuote>We are not merging with machines via wires. We are merging with them via attention.</PullQuote>
 


### PR DESCRIPTION
The wires/attention line appeared in the paragraph AND the pull-quote directly below it (Maria's screenshot). Paragraph trimmed to end at 'psychological codependency.'; the PullQuote owns the line, matching FW08's standalone-quote convention. Gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)