### PR TITLE
feat(stats): private analytics dashboard — visits, argue usage, AEO, SEO

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,12 @@ The phase workflow (concept → context → architecture → assessment → stor
 - **Low-fi Maria-to-camera video is intentional.** Do not suggest polishing it.
 - **AI chat ("argue with me") is a first-class feature**, not a bolt-on. v1 MVP uses Anthropic API + strong system prompt anchored on Maria's voice. v2 adds corpus awareness.
 
+## Analytics & admin surfaces
+
+- **Collection**: Vercel Web Analytics (`<Analytics />` in `layout.tsx`, cookieless) + AI-crawler hit logging in `middleware.ts` (invited bots only, one Blob object per hit under `crawler-hits/`).
+- **Read-back**: `/stats` — private dashboard (visits / argue usage / AEO / SEO), server-rendered, no client JS. Gated by the same Basic-auth as `/argue/log` (`ARGUE_LOG_PASSWORD`). Library code in `src/lib/stats/`.
+- **Env vars**: `VERCEL_API_TOKEN` + `VERCEL_PROJECT_ID` + `VERCEL_TEAM_ID` (visits panel; undocumented dashboard endpoints — shapes pinned in `vercel-analytics.ts`), `GSC_CLIENT_EMAIL` + `GSC_PRIVATE_KEY` (Search Console service account, property `sc-domain:bines.ai`). Every panel has an honest unconfigured/unavailable state — never render a confident zero when the data source is unreachable.
+
 ## PR review flow
 
 Three-tier review protection for every merge to `master`:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Fraunces, Inter, JetBrains_Mono } from 'next/font/google';
+import { Analytics } from '@vercel/analytics/next';
 import './globals.css';
 import { PageShell } from '@/components/PageShell';
 import { JsonLd } from '@/components/JsonLd';
@@ -67,6 +68,9 @@ export default function RootLayout({
         <JsonLd data={websiteJsonLd()} />
         <JsonLd data={personJsonLd()} />
         <PageShell>{children}</PageShell>
+        {/* Vercel Web Analytics collection script. Cookieless, no consent
+            banner required. Read-back lives at /stats (admin-only). */}
+        <Analytics />
       </body>
     </html>
   );

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -6,6 +6,7 @@ import { readCrawlerStats, type CrawlerStats } from '@/lib/stats/crawler-log/rea
 import { readVisitStats, type VisitStats } from '@/lib/stats/vercel-analytics';
 import {
   readSearchConsoleStats,
+  splitBrandQueries,
   type SearchConsoleStats,
 } from '@/lib/stats/search-console';
 
@@ -235,12 +236,12 @@ function VisitsPanel({ visits }: { visits: VisitStats | null }) {
         rows={visits.topPages.map((p) => ({ label: p.path, value: p.views }))}
         valueLabel="views"
       />
-      <SubHeading>referrers · AI surfaces tagged</SubHeading>
+      <SubHeading>referrers · AI surfaces + LinkedIn tagged</SubHeading>
       <RankTable
         rows={visits.referrers.map((r) => ({
           label: r.source || '(direct)',
           value: r.views,
-          badge: r.aiSurface,
+          badge: r.aiSurface ?? r.socialSurface,
         }))}
         valueLabel="views"
       />
@@ -319,6 +320,10 @@ function AeoPanel({
           label="visits referred by AI answers"
           value={aiReferralViews.toLocaleString('en-GB')}
         />
+        <BigNumber
+          label="llms.txt fetches"
+          value={crawlers.llmsTxtHits.toLocaleString('en-GB')}
+        />
       </div>
       <DayBars
         points={crawlers.byDay.map((d) => ({ day: d.day, value: d.hits }))}
@@ -356,6 +361,11 @@ function SeoPanel({ seo }: { seo: SearchConsoleStats }) {
   if (seo.status === 'error') {
     return <Unavailable>Search Console error: {seo.message}</Unavailable>;
   }
+  const { brand, topic, brandPosition } = splitBrandQueries(seo.queries);
+  const queryRow = (q: (typeof seo.queries)[number]) => ({
+    label: `${q.keys[0] ?? ''} · pos ${Math.round(q.position * 10) / 10}`,
+    value: q.impressions,
+  });
   return (
     <>
       <div className="flex flex-wrap gap-x-12 gap-y-4">
@@ -371,15 +381,15 @@ function SeoPanel({ seo }: { seo: SearchConsoleStats }) {
           label="avg position"
           value={seo.totals.position === null ? '—' : String(seo.totals.position)}
         />
+        <BigNumber
+          label="your name, avg position"
+          value={brandPosition === null ? '—' : String(brandPosition)}
+        />
       </div>
-      <SubHeading>queries</SubHeading>
-      <RankTable
-        rows={seo.queries.map((q) => ({
-          label: `${q.keys[0] ?? ''} · pos ${Math.round(q.position * 10) / 10}`,
-          value: q.impressions,
-        }))}
-        valueLabel="impr."
-      />
+      <SubHeading>your name (the query you should own)</SubHeading>
+      <RankTable rows={brand.map(queryRow)} valueLabel="impr." />
+      <SubHeading>topic queries</SubHeading>
+      <RankTable rows={topic.map(queryRow)} valueLabel="impr." />
       <SubHeading>pages</SubHeading>
       <RankTable
         rows={seo.pages.map((p) => ({

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,0 +1,433 @@
+import type { Metadata } from 'next';
+import { readArgueLogDay, listArgueLogDays } from '@/lib/argue-log/storage';
+import { dayKeyUtc } from '@/lib/argue-log/day';
+import { aggregateArgueStats, type ArgueStats } from '@/lib/stats/argue-stats';
+import { readCrawlerStats, type CrawlerStats } from '@/lib/stats/crawler-log/read';
+import { readVisitStats, type VisitStats } from '@/lib/stats/vercel-analytics';
+import {
+  readSearchConsoleStats,
+  type SearchConsoleStats,
+} from '@/lib/stats/search-console';
+
+/**
+ * /stats — Maria's private analytics dashboard.
+ *
+ * Four panels, each with an honest empty/unconfigured state (a panel that
+ * can't reach its data says so — it never shows a confident zero):
+ *   visits  — Vercel Web Analytics read-back (sapphire)
+ *   argue   — chat usage aggregated from the argue-log (ruby)
+ *   aeo     — invited AI-crawler fetches + AI-surface referrals (amethyst)
+ *   seo     — Google Search Console performance (emerald)
+ *
+ * Gated by Basic auth in middleware.ts (shared ARGUE_LOG_PASSWORD), hidden
+ * from robots, absent from the sitemap, linked from nowhere. Server-rendered
+ * HTML only — no client JavaScript, charts are CSS bars.
+ */
+
+export const metadata: Metadata = {
+  title: 'stats',
+  robots: { index: false, follow: false },
+};
+
+export const dynamic = 'force-dynamic';
+
+const WINDOW_DAYS = 28;
+
+function lastNDays(n: number, now: Date): string[] {
+  const out: string[] = [];
+  for (let i = n - 1; i >= 0; i--) {
+    out.push(dayKeyUtc(new Date(now.getTime() - i * 24 * 60 * 60 * 1000)));
+  }
+  return out;
+}
+
+async function loadArgueStats(now: Date): Promise<ArgueStats | null> {
+  try {
+    const windowDays = lastNDays(WINDOW_DAYS, now);
+    // Only fetch days that actually exist in Blob — listArgueLogDays is one
+    // call; absent days contribute empty entries to keep the series gapless.
+    const present = new Set(await listArgueLogDays());
+    const days = await Promise.all(
+      windowDays.map(async (day) => ({
+        day,
+        entries: present.has(day) ? await readArgueLogDay(day) : [],
+      })),
+    );
+    return aggregateArgueStats(days);
+  } catch {
+    return null;
+  }
+}
+
+async function loadCrawlerStats(now: Date): Promise<CrawlerStats | null> {
+  try {
+    return await readCrawlerStats(WINDOW_DAYS, { now });
+  } catch {
+    return null;
+  }
+}
+
+/* ---------- presentation ---------- */
+
+type Jewel = 'sapphire' | 'ruby' | 'amethyst' | 'emerald';
+
+const JEWEL_TEXT: Record<Jewel, string> = {
+  sapphire: 'text-sapphire',
+  ruby: 'text-ruby',
+  amethyst: 'text-amethyst',
+  emerald: 'text-emerald',
+};
+
+const JEWEL_BG: Record<Jewel, string> = {
+  sapphire: 'bg-sapphire',
+  ruby: 'bg-ruby',
+  amethyst: 'bg-amethyst',
+  emerald: 'bg-emerald',
+};
+
+function Panel({
+  title,
+  jewel,
+  children,
+}: {
+  title: string;
+  jewel: Jewel;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="border-t border-ink/10 py-8 first:border-t-0">
+      <h2
+        className={`font-mono text-xs uppercase tracking-wider mb-5 ${JEWEL_TEXT[jewel]}`}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function BigNumber({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="font-serif text-4xl font-light text-ink">{value}</div>
+      <div className="font-mono text-xs text-ink/50 mt-1">{label}</div>
+    </div>
+  );
+}
+
+function Unavailable({ children }: { children: React.ReactNode }) {
+  return <p className="text-sm text-ink/60 m-0">{children}</p>;
+}
+
+/** Server-rendered bar chart — one row per day, width as % of max. */
+function DayBars({
+  points,
+  jewel,
+}: {
+  points: Array<{ day: string; value: number }>;
+  jewel: Jewel;
+}) {
+  const max = Math.max(1, ...points.map((p) => p.value));
+  return (
+    <div className="flex items-end gap-px h-16 mt-4" aria-hidden>
+      {points.map((p) => (
+        <div
+          key={p.day}
+          title={`${p.day}: ${p.value}`}
+          className={`flex-1 min-w-0 ${p.value > 0 ? JEWEL_BG[jewel] : 'bg-ink/10'}`}
+          style={{ height: `${Math.max(2, Math.round((p.value / max) * 100))}%` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function RankTable({
+  rows,
+  valueLabel,
+}: {
+  rows: Array<{ label: string; value: number; badge?: string | null }>;
+  valueLabel: string;
+}) {
+  if (rows.length === 0) {
+    return <p className="text-sm text-ink/50 m-0">nothing yet</p>;
+  }
+  const max = Math.max(1, ...rows.map((r) => r.value));
+  return (
+    <table className="w-full text-sm border-collapse">
+      <tbody>
+        {rows.map((r, i) => (
+          <tr key={`${r.label}-${i}`} className="border-t border-ink/5 first:border-t-0">
+            <td className="py-1.5 pr-3 font-mono text-xs text-ink/80 break-all">
+              {r.label}
+              {r.badge ? (
+                <span className="ml-2 text-amethyst font-medium">
+                  [{r.badge}]
+                </span>
+              ) : null}
+            </td>
+            <td className="py-1.5 w-24 text-right font-mono text-xs text-ink/60">
+              {r.value.toLocaleString('en-GB')} {valueLabel}
+            </td>
+            <td className="py-1.5 pl-3 w-1/4" aria-hidden>
+              <div
+                className="h-1.5 bg-ink/15"
+                style={{ width: `${Math.round((r.value / max) * 100)}%` }}
+              />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function SubHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="font-mono text-xs text-ink/50 mt-6 mb-2">{children}</h3>
+  );
+}
+
+/* ---------- panels ---------- */
+
+function VisitsPanel({ visits }: { visits: VisitStats | null }) {
+  if (!visits) {
+    return (
+      <Unavailable>
+        not configured — set VERCEL_API_TOKEN, VERCEL_PROJECT_ID and
+        VERCEL_TEAM_ID.
+      </Unavailable>
+    );
+  }
+  if (visits.unavailable) {
+    return (
+      <Unavailable>
+        temporarily unavailable — the Vercel analytics endpoints did not
+        answer (this is not the same as zero traffic).
+      </Unavailable>
+    );
+  }
+  return (
+    <>
+      <div className="flex flex-wrap gap-x-12 gap-y-4">
+        <BigNumber
+          label="page views"
+          value={(visits.pageViews ?? 0).toLocaleString('en-GB')}
+        />
+        <BigNumber
+          label="visitors"
+          value={(visits.visitors ?? 0).toLocaleString('en-GB')}
+        />
+        <BigNumber
+          label="bounce rate"
+          value={`${Math.round((visits.bounceRate ?? 0) * 100)}%`}
+        />
+      </div>
+      <DayBars
+        points={visits.timeSeries.map((p) => ({
+          day: p.date,
+          value: p.views,
+        }))}
+        jewel="sapphire"
+      />
+      <SubHeading>top pages</SubHeading>
+      <RankTable
+        rows={visits.topPages.map((p) => ({ label: p.path, value: p.views }))}
+        valueLabel="views"
+      />
+      <SubHeading>referrers · AI surfaces tagged</SubHeading>
+      <RankTable
+        rows={visits.referrers.map((r) => ({
+          label: r.source || '(direct)',
+          value: r.views,
+          badge: r.aiSurface,
+        }))}
+        valueLabel="views"
+      />
+    </>
+  );
+}
+
+function ArguePanel({ argue }: { argue: ArgueStats | null }) {
+  if (!argue) {
+    return (
+      <Unavailable>argue-log unreadable — check BLOB_READ_WRITE_TOKEN.</Unavailable>
+    );
+  }
+  return (
+    <>
+      <div className="flex flex-wrap gap-x-12 gap-y-4">
+        <BigNumber
+          label="conversations"
+          value={argue.conversations.toLocaleString('en-GB')}
+        />
+        <BigNumber
+          label="exchanges"
+          value={argue.exchanges.toLocaleString('en-GB')}
+        />
+        <BigNumber
+          label="refusals"
+          value={argue.refusals.toLocaleString('en-GB')}
+        />
+      </div>
+      <DayBars
+        points={argue.byDay.map((d) => ({ day: d.day, value: d.exchanges }))}
+        jewel="ruby"
+      />
+      <SubHeading>argued from</SubHeading>
+      <RankTable
+        rows={argue.topOrigins.map((o) => ({
+          label: o.origin,
+          value: o.exchanges,
+        }))}
+        valueLabel="exch."
+      />
+      <SubHeading>models</SubHeading>
+      <RankTable
+        rows={argue.models.map((m) => ({ label: m.model, value: m.exchanges }))}
+        valueLabel="exch."
+      />
+    </>
+  );
+}
+
+function AeoPanel({
+  crawlers,
+  visits,
+}: {
+  crawlers: CrawlerStats | null;
+  visits: VisitStats | null;
+}) {
+  const aiReferrals = (visits?.referrers ?? []).filter((r) => r.aiSurface);
+  const aiReferralViews = aiReferrals.reduce((sum, r) => sum + r.views, 0);
+
+  if (!crawlers) {
+    return (
+      <Unavailable>
+        crawler log unreadable — check BLOB_READ_WRITE_TOKEN.
+      </Unavailable>
+    );
+  }
+  return (
+    <>
+      <div className="flex flex-wrap gap-x-12 gap-y-4">
+        <BigNumber
+          label="AI crawler fetches"
+          value={crawlers.totalHits.toLocaleString('en-GB')}
+        />
+        <BigNumber
+          label="visits referred by AI answers"
+          value={aiReferralViews.toLocaleString('en-GB')}
+        />
+      </div>
+      <DayBars
+        points={crawlers.byDay.map((d) => ({ day: d.day, value: d.hits }))}
+        jewel="amethyst"
+      />
+      <SubHeading>by crawler</SubHeading>
+      <RankTable
+        rows={crawlers.byBot.map((b) => ({ label: b.botSlug, value: b.hits }))}
+        valueLabel="fetches"
+      />
+      <SubHeading>what they read</SubHeading>
+      <RankTable
+        rows={crawlers.topPaths.map((p) => ({ label: p.path, value: p.hits }))}
+        valueLabel="fetches"
+      />
+      {crawlers.totalHits === 0 ? (
+        <p className="text-xs text-ink/50 mt-4">
+          counting started when this page shipped — crawlers usually show up
+          within days.
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+function SeoPanel({ seo }: { seo: SearchConsoleStats }) {
+  if (seo.status === 'unconfigured') {
+    return (
+      <Unavailable>
+        not connected — verify bines.ai in Google Search Console, then set
+        GSC_CLIENT_EMAIL and GSC_PRIVATE_KEY.
+      </Unavailable>
+    );
+  }
+  if (seo.status === 'error') {
+    return <Unavailable>Search Console error: {seo.message}</Unavailable>;
+  }
+  return (
+    <>
+      <div className="flex flex-wrap gap-x-12 gap-y-4">
+        <BigNumber
+          label="clicks"
+          value={seo.totals.clicks.toLocaleString('en-GB')}
+        />
+        <BigNumber
+          label="impressions"
+          value={seo.totals.impressions.toLocaleString('en-GB')}
+        />
+        <BigNumber
+          label="avg position"
+          value={seo.totals.position === null ? '—' : String(seo.totals.position)}
+        />
+      </div>
+      <SubHeading>queries</SubHeading>
+      <RankTable
+        rows={seo.queries.map((q) => ({
+          label: `${q.keys[0] ?? ''} · pos ${Math.round(q.position * 10) / 10}`,
+          value: q.impressions,
+        }))}
+        valueLabel="impr."
+      />
+      <SubHeading>pages</SubHeading>
+      <RankTable
+        rows={seo.pages.map((p) => ({
+          label: (p.keys[0] ?? '').replace('https://bines.ai', '') || '/',
+          value: p.impressions,
+        }))}
+        valueLabel="impr."
+      />
+    </>
+  );
+}
+
+/* ---------- page ---------- */
+
+export default async function StatsPage() {
+  const now = new Date();
+  const [visits, argue, crawlers, seo] = await Promise.all([
+    readVisitStats(WINDOW_DAYS, { now }),
+    loadArgueStats(now),
+    loadCrawlerStats(now),
+    readSearchConsoleStats(WINDOW_DAYS, { now }),
+  ]);
+
+  return (
+    <main className="max-w-3xl mx-auto px-6 py-12">
+      <header className="mb-8">
+        <h1 className="font-serif text-3xl font-light text-ink m-0">stats</h1>
+        <p className="font-mono text-xs text-ink/50 mt-2 m-0">
+          trailing {WINDOW_DAYS} days · admin-only · rendered{' '}
+          {now.toISOString().slice(0, 16).replace('T', ' ')} utc
+        </p>
+      </header>
+
+      <Panel title="visits" jewel="sapphire">
+        <VisitsPanel visits={visits} />
+      </Panel>
+
+      <Panel title="argue — the chatbot" jewel="ruby">
+        <ArguePanel argue={argue} />
+      </Panel>
+
+      <Panel title="aeo — answer engines" jewel="amethyst">
+        <AeoPanel crawlers={crawlers} visits={visits} />
+      </Panel>
+
+      <Panel title="seo — google search" jewel="emerald">
+        <SeoPanel seo={seo} />
+      </Panel>
+    </main>
+  );
+}

--- a/src/lib/stats/__tests__/ai-crawlers.test.ts
+++ b/src/lib/stats/__tests__/ai-crawlers.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+  identifyAiCrawler,
+  identifyAiReferrer,
+  botSlug,
+} from '../ai-crawlers';
+
+describe('identifyAiCrawler', () => {
+  it('identifies the invited AI crawlers from realistic UA strings', () => {
+    expect(
+      identifyAiCrawler(
+        'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; GPTBot/1.2; +https://openai.com/gptbot',
+      ),
+    ).toBe('GPTBot');
+    expect(
+      identifyAiCrawler(
+        'Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)',
+      ),
+    ).toBe('ClaudeBot');
+    expect(
+      identifyAiCrawler('Mozilla/5.0 (compatible; PerplexityBot/1.0)'),
+    ).toBe('PerplexityBot');
+    expect(
+      identifyAiCrawler('Mozilla/5.0 (compatible; OAI-SearchBot/1.0)'),
+    ).toBe('OAI-SearchBot');
+    expect(identifyAiCrawler('Mozilla/5.0; Google-Extended')).toBe(
+      'Google-Extended',
+    );
+  });
+
+  it('distinguishes the -User fetchers from the crawl bots', () => {
+    expect(identifyAiCrawler('ChatGPT-User/1.0')).toBe('ChatGPT-User');
+    expect(identifyAiCrawler('Perplexity-User/1.0')).toBe('Perplexity-User');
+  });
+
+  it('returns null for browsers, search bots, and empty UAs', () => {
+    expect(
+      identifyAiCrawler('Mozilla/5.0 (Macintosh) Safari/605.1.15'),
+    ).toBeNull();
+    expect(
+      identifyAiCrawler('Mozilla/5.0 (compatible; Googlebot/2.1)'),
+    ).toBeNull();
+    expect(identifyAiCrawler('')).toBeNull();
+  });
+});
+
+describe('identifyAiReferrer', () => {
+  it('identifies AI answer surfaces from hosts and full URLs', () => {
+    expect(identifyAiReferrer('https://chatgpt.com/')).toBe('ChatGPT');
+    expect(identifyAiReferrer('chat.openai.com')).toBe('ChatGPT');
+    expect(identifyAiReferrer('https://www.perplexity.ai')).toBe('Perplexity');
+    expect(identifyAiReferrer('copilot.microsoft.com')).toBe('Copilot');
+    expect(identifyAiReferrer('claude.ai')).toBe('Claude');
+  });
+
+  it('returns null for ordinary referrers and empty strings', () => {
+    expect(identifyAiReferrer('https://www.google.com')).toBeNull();
+    expect(identifyAiReferrer('linkedin.com')).toBeNull();
+    expect(identifyAiReferrer('')).toBeNull();
+  });
+});
+
+describe('botSlug', () => {
+  it('lowercases and dashes display names', () => {
+    expect(botSlug('OAI-SearchBot')).toBe('oai-searchbot');
+    expect(botSlug('Google-Extended')).toBe('google-extended');
+    expect(botSlug('ChatGPT-User')).toBe('chatgpt-user');
+  });
+});

--- a/src/lib/stats/__tests__/ai-crawlers.test.ts
+++ b/src/lib/stats/__tests__/ai-crawlers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   identifyAiCrawler,
   identifyAiReferrer,
+  identifySocialReferrer,
   botSlug,
 } from '../ai-crawlers';
 
@@ -57,6 +58,21 @@ describe('identifyAiReferrer', () => {
     expect(identifyAiReferrer('https://www.google.com')).toBeNull();
     expect(identifyAiReferrer('linkedin.com')).toBeNull();
     expect(identifyAiReferrer('')).toBeNull();
+  });
+});
+
+describe('identifySocialReferrer', () => {
+  it('identifies LinkedIn including the short domain', () => {
+    expect(identifySocialReferrer('https://www.linkedin.com/feed/')).toBe(
+      'LinkedIn',
+    );
+    expect(identifySocialReferrer('https://lnkd.in/abc')).toBe('LinkedIn');
+  });
+
+  it('returns null for everything else', () => {
+    expect(identifySocialReferrer('https://www.google.com')).toBeNull();
+    expect(identifySocialReferrer('https://chatgpt.com')).toBeNull();
+    expect(identifySocialReferrer('')).toBeNull();
   });
 });
 

--- a/src/lib/stats/__tests__/argue-stats.test.ts
+++ b/src/lib/stats/__tests__/argue-stats.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { aggregateArgueStats } from '../argue-stats';
+import type { ArgueLogEntry } from '@/lib/argue-log/schema';
+
+const CONV_A = '11111111-1111-4111-8111-111111111111';
+const CONV_B = '22222222-2222-4222-8222-222222222222';
+
+function entry(overrides: Partial<ArgueLogEntry> = {}): ArgueLogEntry {
+  return {
+    schema_version: 1,
+    timestamp: '2026-06-12T09:00:00.000Z',
+    ip_hash: 'a'.repeat(64),
+    salt_version: 'current',
+    turns: [{ role: 'user', content: 'hello' }],
+    guard_signals: [],
+    verdict: { harm: 'none', off_brand: [] },
+    refused: false,
+    model: 'claude-sonnet-4-6',
+    latency_ms: { pre_flight: 10, stream: 100 },
+    conversation_id: CONV_A,
+    from_slug: null,
+    ...overrides,
+  };
+}
+
+describe('aggregateArgueStats', () => {
+  it('counts distinct conversations across days, exchanges and refusals', () => {
+    const stats = aggregateArgueStats([
+      {
+        day: '2026-06-11',
+        entries: [
+          entry({ conversation_id: CONV_A }),
+          entry({ conversation_id: CONV_A, refused: true }),
+        ],
+      },
+      {
+        day: '2026-06-12',
+        entries: [
+          entry({ conversation_id: CONV_A }),
+          entry({ conversation_id: CONV_B }),
+        ],
+      },
+    ]);
+
+    expect(stats.conversations).toBe(2); // A spans both days, counted once
+    expect(stats.exchanges).toBe(4);
+    expect(stats.refusals).toBe(1);
+    expect(stats.byDay).toEqual([
+      { day: '2026-06-11', conversations: 1, exchanges: 2 },
+      { day: '2026-06-12', conversations: 2, exchanges: 2 },
+    ]);
+  });
+
+  it('counts pre-Phase-A entries (no conversation_id) as one conversation each', () => {
+    const legacy = entry();
+    delete (legacy as Partial<ArgueLogEntry>).conversation_id;
+    const stats = aggregateArgueStats([
+      { day: '2026-06-12', entries: [legacy, legacy, entry()] },
+    ]);
+    expect(stats.conversations).toBe(3); // 2 unthreaded + 1 threaded
+  });
+
+  it('buckets origins: from_slug, null → direct, sorted desc', () => {
+    const stats = aggregateArgueStats([
+      {
+        day: '2026-06-12',
+        entries: [
+          entry({ from_slug: '10-excellent-manners' }),
+          entry({ from_slug: '10-excellent-manners' }),
+          entry({ from_slug: null }),
+        ],
+      },
+    ]);
+    expect(stats.topOrigins).toEqual([
+      { origin: '10-excellent-manners', exchanges: 2 },
+      { origin: 'direct', exchanges: 1 },
+    ]);
+  });
+
+  it('skips empty models (refusals) in the model table and handles empty input', () => {
+    const stats = aggregateArgueStats([
+      { day: '2026-06-12', entries: [entry({ model: '', refused: true })] },
+    ]);
+    expect(stats.models).toEqual([]);
+
+    const empty = aggregateArgueStats([]);
+    expect(empty.conversations).toBe(0);
+    expect(empty.byDay).toEqual([]);
+  });
+});

--- a/src/lib/stats/__tests__/search-console.test.ts
+++ b/src/lib/stats/__tests__/search-console.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { generateKeyPairSync, webcrypto } from 'node:crypto';
-import { readSearchConsoleStats } from '../search-console';
+import {
+  readSearchConsoleStats,
+  splitBrandQueries,
+  type SearchRow,
+} from '../search-console';
 
 const ORIG_EMAIL = process.env.GSC_CLIENT_EMAIL;
 const ORIG_KEY = process.env.GSC_PRIVATE_KEY;
@@ -120,5 +124,43 @@ describe('readSearchConsoleStats', () => {
       position: null,
     });
     expect(stats.queries).toEqual([]);
+  });
+});
+
+describe('splitBrandQueries', () => {
+  const row = (q: string, impressions: number, position: number): SearchRow => ({
+    keys: [q],
+    clicks: 1,
+    impressions,
+    ctr: 0.1,
+    position,
+  });
+
+  it('splits name queries from topic queries', () => {
+    const { brand, topic } = splitBrandQueries([
+      row('maria bines', 100, 1.2),
+      row('bines.ai', 50, 1.0),
+      row('ai essays uk', 200, 40),
+      row('submarine movies', 10, 80), // contains "marine", not "maria"
+    ]);
+    expect(brand.map((r) => r.keys[0])).toEqual(['maria bines', 'bines.ai']);
+    expect(topic.map((r) => r.keys[0])).toEqual([
+      'ai essays uk',
+      'submarine movies',
+    ]);
+  });
+
+  it('weights brand position by impressions, 1dp', () => {
+    const { brandPosition } = splitBrandQueries([
+      row('maria bines', 100, 1.0),
+      row('who is maria bines', 50, 4.0),
+    ]);
+    // (1.0*100 + 4.0*50) / 150 = 2.0
+    expect(brandPosition).toBe(2);
+  });
+
+  it('returns null position when no brand impressions exist', () => {
+    const { brandPosition } = splitBrandQueries([row('ai essays', 10, 5)]);
+    expect(brandPosition).toBeNull();
   });
 });

--- a/src/lib/stats/__tests__/search-console.test.ts
+++ b/src/lib/stats/__tests__/search-console.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { generateKeyPairSync, webcrypto } from 'node:crypto';
+import { readSearchConsoleStats } from '../search-console';
+
+const ORIG_EMAIL = process.env.GSC_CLIENT_EMAIL;
+const ORIG_KEY = process.env.GSC_PRIVATE_KEY;
+
+const NOW = new Date('2026-06-12T12:00:00.000Z');
+
+// A real (throwaway) RSA key so the WebCrypto RS256 signing path runs for
+// real — only the network is mocked. jsdom lacks crypto.subtle; use Node's.
+const { privateKey: TEST_PEM } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal('crypto', webcrypto);
+  process.env.GSC_CLIENT_EMAIL = 'stats@test-project.iam.gserviceaccount.com';
+  // Vercel env vars flatten newlines to literal \n — exercise that path.
+  process.env.GSC_PRIVATE_KEY = TEST_PEM.replace(/\n/g, '\\n');
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  if (ORIG_EMAIL === undefined) delete process.env.GSC_CLIENT_EMAIL;
+  else process.env.GSC_CLIENT_EMAIL = ORIG_EMAIL;
+  if (ORIG_KEY === undefined) delete process.env.GSC_PRIVATE_KEY;
+  else process.env.GSC_PRIVATE_KEY = ORIG_KEY;
+});
+
+describe('readSearchConsoleStats', () => {
+  it('returns unconfigured when env vars are absent', async () => {
+    delete process.env.GSC_CLIENT_EMAIL;
+    delete process.env.GSC_PRIVATE_KEY;
+    expect(await readSearchConsoleStats(28, { now: NOW })).toEqual({
+      status: 'unconfigured',
+    });
+  });
+
+  it('signs a JWT, exchanges it, and maps the three queries', async () => {
+    const row = (keys: string[] | undefined, impressions: number) => ({
+      ...(keys ? { keys } : {}),
+      clicks: 3,
+      impressions,
+      ctr: 0.1,
+      position: 7.43,
+    });
+    const fetchMock = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (u.includes('oauth2.googleapis.com/token')) {
+        const body = String(init?.body);
+        expect(body).toContain('jwt-bearer');
+        // assertion=<header>.<claims>.<sig>
+        expect(body.split('assertion=')[1].split('.').length).toBe(3);
+        return jsonResponse({ access_token: 'ya29.test' });
+      }
+      expect(u).toContain(encodeURIComponent('sc-domain:bines.ai'));
+      const body = JSON.parse(String(init?.body)) as {
+        dimensions?: string[];
+      };
+      if (!body.dimensions) return jsonResponse({ rows: [row(undefined, 200)] });
+      if (body.dimensions[0] === 'query') {
+        return jsonResponse({ rows: [row(['boring ai'], 120)] });
+      }
+      return jsonResponse({
+        rows: [row(['https://bines.ai/fieldwork/10-excellent-manners'], 80)],
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const stats = await readSearchConsoleStats(28, { now: NOW });
+
+    expect(stats.status).toBe('ok');
+    if (stats.status !== 'ok') return;
+    expect(stats.totals).toEqual({
+      clicks: 3,
+      impressions: 200,
+      position: 7.4,
+    });
+    expect(stats.queries[0].keys[0]).toBe('boring ai');
+    expect(stats.pages[0].impressions).toBe(80);
+  });
+
+  it('returns an error status when the token exchange fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ error: 'invalid_grant' }, 403)),
+    );
+    const stats = await readSearchConsoleStats(28, { now: NOW });
+    expect(stats.status).toBe('error');
+    if (stats.status === 'error') {
+      expect(stats.message).toMatch(/token exchange failed/);
+    }
+  });
+
+  it('handles an empty property (no rows) without inventing totals', async () => {
+    const fetchMock = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url).includes('oauth2.googleapis.com/token')) {
+        return jsonResponse({ access_token: 'ya29.test' });
+      }
+      return jsonResponse({}); // GSC omits `rows` entirely for empty windows
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const stats = await readSearchConsoleStats(28, { now: NOW });
+    expect(stats.status).toBe('ok');
+    if (stats.status !== 'ok') return;
+    expect(stats.totals).toEqual({
+      clicks: 0,
+      impressions: 0,
+      position: null,
+    });
+    expect(stats.queries).toEqual([]);
+  });
+});

--- a/src/lib/stats/__tests__/search-console.test.ts
+++ b/src/lib/stats/__tests__/search-console.test.ts
@@ -1,5 +1,12 @@
+// @vitest-environment node
+//
+// The JWT signing path needs a real crypto.subtle. jsdom doesn't provide
+// one, and stubbing the `crypto` global works on some Node versions and
+// not others (passed locally on 24, failed on CI's 20). Running this one
+// file in the node environment uses Node's native WebCrypto — the same
+// global the code sees in production — with no stubbing at all.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { generateKeyPairSync, webcrypto } from 'node:crypto';
+import { generateKeyPairSync } from 'node:crypto';
 import {
   readSearchConsoleStats,
   splitBrandQueries,
@@ -12,7 +19,7 @@ const ORIG_KEY = process.env.GSC_PRIVATE_KEY;
 const NOW = new Date('2026-06-12T12:00:00.000Z');
 
 // A real (throwaway) RSA key so the WebCrypto RS256 signing path runs for
-// real — only the network is mocked. jsdom lacks crypto.subtle; use Node's.
+// real — only the network is mocked.
 const { privateKey: TEST_PEM } = generateKeyPairSync('rsa', {
   modulusLength: 2048,
   privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
@@ -27,7 +34,6 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 beforeEach(() => {
-  vi.stubGlobal('crypto', webcrypto);
   process.env.GSC_CLIENT_EMAIL = 'stats@test-project.iam.gserviceaccount.com';
   // Vercel env vars flatten newlines to literal \n — exercise that path.
   process.env.GSC_PRIVATE_KEY = TEST_PEM.replace(/\n/g, '\\n');

--- a/src/lib/stats/__tests__/vercel-analytics.test.ts
+++ b/src/lib/stats/__tests__/vercel-analytics.test.ts
@@ -62,6 +62,7 @@ describe('readVisitStats', () => {
         data: [
           { key: 'https://chatgpt.com/', total: 7 },
           { key: 'https://www.google.com/', total: 5 },
+          { key: 'https://www.linkedin.com/', total: 4 },
         ],
       });
     });
@@ -76,7 +77,9 @@ describe('readVisitStats', () => {
     expect(stats?.timeSeries).toHaveLength(2);
     expect(stats?.topPages[0]).toEqual({ path: '/postcards', views: 30 });
     expect(stats?.referrers[0].aiSurface).toBe('ChatGPT');
+    expect(stats?.referrers[0].socialSurface).toBeNull();
     expect(stats?.referrers[1].aiSurface).toBeNull();
+    expect(stats?.referrers[2].socialSurface).toBe('LinkedIn');
 
     // Every call carries teamId — the endpoints 404 without it.
     for (const call of fetchMock.mock.calls) {

--- a/src/lib/stats/__tests__/vercel-analytics.test.ts
+++ b/src/lib/stats/__tests__/vercel-analytics.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readVisitStats } from '../vercel-analytics';
+
+const ENV_KEYS = [
+  'VERCEL_API_TOKEN',
+  'VERCEL_PROJECT_ID',
+  'VERCEL_TEAM_ID',
+] as const;
+const ORIG = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+
+const NOW = new Date('2026-06-12T12:00:00.000Z');
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  process.env.VERCEL_API_TOKEN = 'tok';
+  process.env.VERCEL_PROJECT_ID = 'prj_test';
+  process.env.VERCEL_TEAM_ID = 'team_test';
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (ORIG[k] === undefined) delete process.env[k];
+    else process.env[k] = ORIG[k];
+  }
+  vi.unstubAllGlobals();
+});
+
+describe('readVisitStats', () => {
+  it('returns null when env vars are not configured', async () => {
+    delete process.env.VERCEL_API_TOKEN;
+    expect(await readVisitStats(28, { now: NOW })).toBeNull();
+  });
+
+  it('maps the dashboard endpoint shapes and tags AI referrers', async () => {
+    const fetchMock = vi.fn(async (url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u.includes('/overview')) {
+        return jsonResponse({ total: 120, devices: 80, bounceRate: 0.45 });
+      }
+      if (u.includes('/timeseries')) {
+        return jsonResponse({
+          data: {
+            groups: {
+              all: [
+                { key: '2026-06-11', total: 60, devices: 40 },
+                { key: '2026-06-12', total: 60, devices: 40 },
+              ],
+            },
+          },
+        });
+      }
+      if (u.includes('type=path')) {
+        return jsonResponse({ data: [{ key: '/postcards', total: 30 }] });
+      }
+      return jsonResponse({
+        data: [
+          { key: 'https://chatgpt.com/', total: 7 },
+          { key: 'https://www.google.com/', total: 5 },
+        ],
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const stats = await readVisitStats(28, { now: NOW });
+
+    expect(stats).not.toBeNull();
+    expect(stats?.unavailable).toBe(false);
+    expect(stats?.pageViews).toBe(120);
+    expect(stats?.visitors).toBe(80);
+    expect(stats?.timeSeries).toHaveLength(2);
+    expect(stats?.topPages[0]).toEqual({ path: '/postcards', views: 30 });
+    expect(stats?.referrers[0].aiSurface).toBe('ChatGPT');
+    expect(stats?.referrers[1].aiSurface).toBeNull();
+
+    // Every call carries teamId — the endpoints 404 without it.
+    for (const call of fetchMock.mock.calls) {
+      expect(String(call[0])).toContain('teamId=team_test');
+    }
+  });
+
+  it('reports unavailable (not zeros) when all endpoints fail', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('nope', { status: 403 })),
+    );
+    const stats = await readVisitStats(28, { now: NOW });
+    expect(stats?.unavailable).toBe(true);
+    expect(stats?.pageViews).toBeNull();
+    expect(stats?.visitors).toBeNull();
+  });
+
+  it('survives a thrown fetch (network down) as unavailable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down');
+      }),
+    );
+    const stats = await readVisitStats(28, { now: NOW });
+    expect(stats?.unavailable).toBe(true);
+  });
+});

--- a/src/lib/stats/ai-crawlers.ts
+++ b/src/lib/stats/ai-crawlers.ts
@@ -1,0 +1,75 @@
+/**
+ * AI crawler + AI referrer identification for the AEO panel on /stats.
+ *
+ * Pure, no env, no I/O — safe to import from middleware (edge) and from
+ * server components alike.
+ *
+ * The crawler table mirrors the *invited* AI bots in src/app/robots.ts.
+ * If a bot is added or removed there, update this table in the same PR
+ * (the /stats AEO panel counts only bots we have chosen to welcome —
+ * blocked scrapers get a 403 in middleware and are deliberately not part
+ * of the answer-engine story).
+ */
+
+/** UA substring (lowercase) → display name shown on /stats. Order matters:
+ * first match wins, so more specific substrings come before generic ones
+ * (e.g. 'chatgpt-user' before 'gptbot' is not required, but 'perplexity-user'
+ * must precede 'perplexity'). */
+const AI_CRAWLER_TABLE: ReadonlyArray<readonly [string, string]> = [
+  ['oai-searchbot', 'OAI-SearchBot'],
+  ['chatgpt-user', 'ChatGPT-User'],
+  ['gptbot', 'GPTBot'],
+  ['perplexity-user', 'Perplexity-User'],
+  ['perplexitybot', 'PerplexityBot'],
+  ['claudebot', 'ClaudeBot'],
+  ['claude-web', 'Claude-Web'],
+  ['anthropic-ai', 'Anthropic-AI'],
+  ['google-extended', 'Google-Extended'],
+  ['applebot-extended', 'Applebot-Extended'],
+  ['youbot', 'YouBot'],
+];
+
+/**
+ * Identify an invited AI crawler from a User-Agent header.
+ * Returns the display name, or null when the UA is not a known AI crawler.
+ */
+export function identifyAiCrawler(userAgent: string): string | null {
+  const ua = userAgent.toLowerCase();
+  if (!ua) return null;
+  for (const [needle, name] of AI_CRAWLER_TABLE) {
+    if (ua.includes(needle)) return name;
+  }
+  return null;
+}
+
+/** Referrer host substring (lowercase) → AI surface name. Used to break out
+ * "humans arriving from an AI answer" in the visits referrer table. */
+const AI_REFERRER_TABLE: ReadonlyArray<readonly [string, string]> = [
+  ['chatgpt.com', 'ChatGPT'],
+  ['chat.openai.com', 'ChatGPT'],
+  ['perplexity.ai', 'Perplexity'],
+  ['copilot.microsoft.com', 'Copilot'],
+  ['gemini.google.com', 'Gemini'],
+  ['claude.ai', 'Claude'],
+  ['you.com', 'You.com'],
+  ['chat.deepseek.com', 'DeepSeek'],
+];
+
+/**
+ * Identify an AI answer-surface from a referrer string (full URL or bare
+ * host — both occur in Vercel's referrer stats). Returns the surface name,
+ * or null for ordinary referrers.
+ */
+export function identifyAiReferrer(referrer: string): string | null {
+  const ref = referrer.toLowerCase();
+  if (!ref) return null;
+  for (const [needle, name] of AI_REFERRER_TABLE) {
+    if (ref.includes(needle)) return name;
+  }
+  return null;
+}
+
+/** Slug-safe form of a bot display name, used in Blob pathnames. */
+export function botSlug(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+}

--- a/src/lib/stats/ai-crawlers.ts
+++ b/src/lib/stats/ai-crawlers.ts
@@ -69,6 +69,26 @@ export function identifyAiReferrer(referrer: string): string | null {
   return null;
 }
 
+/** Referrer host substrings for the social channel Maria actually uses.
+ * LinkedIn is the only social surface for bines.ai (locked decision), so
+ * it gets its own badge in the referrer table — it's the main human
+ * distribution channel and worth seeing at a glance. */
+const SOCIAL_REFERRER_TABLE: ReadonlyArray<readonly [string, string]> = [
+  ['linkedin.com', 'LinkedIn'],
+  ['lnkd.in', 'LinkedIn'],
+];
+
+/** Identify a social surface from a referrer string. Same matching
+ * semantics as identifyAiReferrer. */
+export function identifySocialReferrer(referrer: string): string | null {
+  const ref = referrer.toLowerCase();
+  if (!ref) return null;
+  for (const [needle, name] of SOCIAL_REFERRER_TABLE) {
+    if (ref.includes(needle)) return name;
+  }
+  return null;
+}
+
 /** Slug-safe form of a bot display name, used in Blob pathnames. */
 export function botSlug(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9]+/g, '-');

--- a/src/lib/stats/argue-stats.ts
+++ b/src/lib/stats/argue-stats.ts
@@ -1,0 +1,85 @@
+import type { ArgueLogEntry } from '@/lib/argue-log/schema';
+
+/**
+ * Aggregation over argue-log entries for the /stats chat panel.
+ *
+ * The pure aggregator is separated from the Blob-reading loader so it can
+ * be unit-tested without storage mocks. Loading lives in the page (it
+ * composes readArgueLogDay, which is already tested in argue-log).
+ */
+
+export interface ArgueDayEntries {
+  day: string;
+  entries: ArgueLogEntry[];
+}
+
+export interface ArgueStats {
+  /** Distinct conversations. Entries without a conversation_id (pre-Phase-A
+   * log lines) each count as their own conversation — the honest reading
+   * of a log line that cannot be threaded. */
+  conversations: number;
+  /** Total round-trips (one entry = one user turn answered or refused). */
+  exchanges: number;
+  refusals: number;
+  /** Oldest → newest; zero-entry days included so the series has no gaps. */
+  byDay: Array<{ day: string; conversations: number; exchanges: number }>;
+  /** Fieldwork slugs visitors argued from, sorted desc. null from_slug
+   * (direct /argue visits) reported under 'direct'. */
+  topOrigins: Array<{ origin: string; exchanges: number }>;
+  models: Array<{ model: string; exchanges: number }>;
+}
+
+export function aggregateArgueStats(days: ArgueDayEntries[]): ArgueStats {
+  const allConversations = new Set<string>();
+  const origins = new Map<string, number>();
+  const models = new Map<string, number>();
+  const byDay: ArgueStats['byDay'] = [];
+  let exchanges = 0;
+  let refusals = 0;
+  let unthreaded = 0;
+
+  for (const { day, entries } of days) {
+    const dayConversations = new Set<string>();
+    let dayUnthreaded = 0;
+    for (const e of entries) {
+      exchanges += 1;
+      if (e.refused) refusals += 1;
+
+      if (e.conversation_id) {
+        allConversations.add(e.conversation_id);
+        dayConversations.add(e.conversation_id);
+      } else {
+        unthreaded += 1;
+        dayUnthreaded += 1;
+      }
+
+      const origin =
+        e.from_slug === undefined || e.from_slug === null
+          ? 'direct'
+          : e.from_slug;
+      origins.set(origin, (origins.get(origin) ?? 0) + 1);
+
+      if (e.model) models.set(e.model, (models.get(e.model) ?? 0) + 1);
+    }
+    byDay.push({
+      day,
+      conversations: dayConversations.size + dayUnthreaded,
+      exchanges: entries.length,
+    });
+  }
+
+  const desc = (m: Map<string, number>) =>
+    [...m.entries()].sort((a, b) => b[1] - a[1]);
+
+  return {
+    conversations: allConversations.size + unthreaded,
+    exchanges,
+    refusals,
+    byDay,
+    topOrigins: desc(origins).map(([origin, n]) => ({
+      origin,
+      exchanges: n,
+    })),
+    models: desc(models).map(([model, n]) => ({ model, exchanges: n })),
+  };
+}

--- a/src/lib/stats/crawler-log/__tests__/append.test.ts
+++ b/src/lib/stats/crawler-log/__tests__/append.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@vercel/blob', () => ({
+  put: vi.fn(),
+  list: vi.fn(),
+}));
+
+import { put } from '@vercel/blob';
+import { appendCrawlerHit } from '../append';
+import { parseHitPathname, type CrawlerHit } from '../schema';
+
+const putMock = vi.mocked(put);
+const ORIG_TOKEN = process.env.BLOB_READ_WRITE_TOKEN;
+
+function hit(): CrawlerHit {
+  return {
+    schema_version: 1,
+    timestamp: '2026-06-12T09:00:00.000Z',
+    bot: 'ClaudeBot',
+    path: '/postcards',
+    ua: 'ClaudeBot/1.0',
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.BLOB_READ_WRITE_TOKEN = 'test-token';
+});
+
+afterEach(() => {
+  process.env.BLOB_READ_WRITE_TOKEN = ORIG_TOKEN;
+});
+
+describe('appendCrawlerHit', () => {
+  it('writes one private JSON object with a parseable pathname', async () => {
+    putMock.mockResolvedValue({} as never);
+    await appendCrawlerHit(hit());
+
+    expect(putMock).toHaveBeenCalledTimes(1);
+    const [pathname, body, opts] = putMock.mock.calls[0];
+    expect(parseHitPathname(pathname as string)).toEqual({
+      day: '2026-06-12',
+      botSlug: 'claudebot',
+      path: '/postcards',
+    });
+    expect(JSON.parse(body as string)).toEqual(hit());
+    expect(opts).toMatchObject({
+      access: 'private',
+      addRandomSuffix: false,
+      token: 'test-token',
+    });
+  });
+
+  it('rejects malformed hits before any Blob call', async () => {
+    await expect(
+      appendCrawlerHit({ ...hit(), bot: '' }),
+    ).rejects.toThrow();
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  it('throws when BLOB_READ_WRITE_TOKEN is missing', async () => {
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+    await expect(appendCrawlerHit(hit())).rejects.toThrow(
+      /BLOB_READ_WRITE_TOKEN/,
+    );
+    expect(putMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/stats/crawler-log/__tests__/read.test.ts
+++ b/src/lib/stats/crawler-log/__tests__/read.test.ts
@@ -59,24 +59,28 @@ describe('readCrawlerStats', () => {
         ]);
       }
       if (prefix === 'crawler-hits/2026-06-11/') {
-        return page([blobFor('2026-06-11', 'GPTBot', '/about', 'r4')]);
+        return page([
+          blobFor('2026-06-11', 'GPTBot', '/about', 'r4'),
+          blobFor('2026-06-11', 'ClaudeBot', '/llms.txt', 'r5'),
+        ]);
       }
       return page([]);
     });
 
     const stats = await readCrawlerStats(3, { now: NOW });
 
-    expect(stats.totalHits).toBe(4);
+    expect(stats.totalHits).toBe(5);
     expect(stats.byBot).toEqual([
       { botSlug: 'gptbot', hits: 3 },
-      { botSlug: 'claudebot', hits: 1 },
+      { botSlug: 'claudebot', hits: 2 },
     ]);
     expect(stats.byDay).toEqual([
       { day: '2026-06-10', hits: 0 },
-      { day: '2026-06-11', hits: 1 },
+      { day: '2026-06-11', hits: 2 },
       { day: '2026-06-12', hits: 3 },
     ]);
     expect(stats.topPaths[0]).toEqual({ path: '/postcards', hits: 2 });
+    expect(stats.llmsTxtHits).toBe(1);
   });
 
   it('follows pagination cursors within a day', async () => {

--- a/src/lib/stats/crawler-log/__tests__/read.test.ts
+++ b/src/lib/stats/crawler-log/__tests__/read.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@vercel/blob', () => ({
+  put: vi.fn(),
+  list: vi.fn(),
+}));
+
+import { list } from '@vercel/blob';
+import { readCrawlerStats } from '../read';
+import { hitPathname } from '../schema';
+
+const listMock = vi.mocked(list);
+const ORIG_TOKEN = process.env.BLOB_READ_WRITE_TOKEN;
+
+const NOW = new Date('2026-06-12T12:00:00.000Z');
+
+function blobFor(day: string, bot: string, path: string, rand: string) {
+  return {
+    pathname: hitPathname(
+      {
+        schema_version: 1,
+        timestamp: `${day}T09:00:00.000Z`,
+        bot,
+        path,
+        ua: 'x',
+      },
+      Date.parse(`${day}T09:00:00.000Z`),
+      rand,
+    ),
+  };
+}
+
+function page(blobs: Array<{ pathname: string }>, cursor?: string) {
+  return {
+    blobs,
+    hasMore: Boolean(cursor),
+    cursor,
+  } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.BLOB_READ_WRITE_TOKEN = 'test-token';
+});
+
+afterEach(() => {
+  process.env.BLOB_READ_WRITE_TOKEN = ORIG_TOKEN;
+});
+
+describe('readCrawlerStats', () => {
+  it('aggregates by bot, day and path from pathnames alone', async () => {
+    listMock.mockImplementation(async (opts) => {
+      const prefix = opts?.prefix;
+      if (prefix === 'crawler-hits/2026-06-12/') {
+        return page([
+          blobFor('2026-06-12', 'GPTBot', '/postcards', 'r1'),
+          blobFor('2026-06-12', 'GPTBot', '/postcards', 'r2'),
+          blobFor('2026-06-12', 'ClaudeBot', '/', 'r3'),
+        ]);
+      }
+      if (prefix === 'crawler-hits/2026-06-11/') {
+        return page([blobFor('2026-06-11', 'GPTBot', '/about', 'r4')]);
+      }
+      return page([]);
+    });
+
+    const stats = await readCrawlerStats(3, { now: NOW });
+
+    expect(stats.totalHits).toBe(4);
+    expect(stats.byBot).toEqual([
+      { botSlug: 'gptbot', hits: 3 },
+      { botSlug: 'claudebot', hits: 1 },
+    ]);
+    expect(stats.byDay).toEqual([
+      { day: '2026-06-10', hits: 0 },
+      { day: '2026-06-11', hits: 1 },
+      { day: '2026-06-12', hits: 3 },
+    ]);
+    expect(stats.topPaths[0]).toEqual({ path: '/postcards', hits: 2 });
+  });
+
+  it('follows pagination cursors within a day', async () => {
+    listMock
+      .mockResolvedValueOnce(
+        page([blobFor('2026-06-12', 'GPTBot', '/a', 'r1')], 'cursor-1'),
+      )
+      .mockResolvedValueOnce(
+        page([blobFor('2026-06-12', 'GPTBot', '/b', 'r2')]),
+      );
+
+    const stats = await readCrawlerStats(1, { now: NOW });
+    expect(stats.totalHits).toBe(2);
+    expect(listMock).toHaveBeenCalledTimes(2);
+    expect(listMock.mock.calls[1][0]).toMatchObject({ cursor: 'cursor-1' });
+  });
+
+  it('skips foreign pathnames and throws without a token', async () => {
+    listMock.mockResolvedValue(
+      page([{ pathname: 'crawler-hits/2026-06-12/readme.txt' }]),
+    );
+    const stats = await readCrawlerStats(1, { now: NOW });
+    expect(stats.totalHits).toBe(0);
+
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+    await expect(readCrawlerStats(1, { now: NOW })).rejects.toThrow(
+      /BLOB_READ_WRITE_TOKEN/,
+    );
+  });
+});

--- a/src/lib/stats/crawler-log/__tests__/schema.test.ts
+++ b/src/lib/stats/crawler-log/__tests__/schema.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CRAWLER_HIT,
+  encodePath,
+  decodePath,
+  hitPathname,
+  parseHitPathname,
+  type CrawlerHit,
+} from '../schema';
+
+function hit(overrides: Partial<CrawlerHit> = {}): CrawlerHit {
+  return {
+    schema_version: 1,
+    timestamp: '2026-06-12T09:00:00.000Z',
+    bot: 'GPTBot',
+    path: '/fieldwork/10-excellent-manners',
+    ua: 'GPTBot/1.2',
+    ...overrides,
+  };
+}
+
+describe('CRAWLER_HIT schema', () => {
+  it('accepts a valid hit', () => {
+    expect(CRAWLER_HIT.safeParse(hit()).success).toBe(true);
+  });
+
+  it('rejects missing bot and over-long fields', () => {
+    expect(CRAWLER_HIT.safeParse(hit({ bot: '' })).success).toBe(false);
+    expect(
+      CRAWLER_HIT.safeParse(hit({ path: '/'.padEnd(501, 'x') })).success,
+    ).toBe(false);
+    expect(
+      CRAWLER_HIT.safeParse(hit({ ua: 'u'.repeat(301) })).success,
+    ).toBe(false);
+  });
+});
+
+describe('encodePath / decodePath', () => {
+  it('round-trips paths including unicode', () => {
+    for (const p of ['/', '/fieldwork/10-excellent-manners', '/tag/café']) {
+      expect(decodePath(encodePath(p))).toBe(p);
+    }
+  });
+
+  it('produces pathname-safe output (no +, /, =)', () => {
+    const encoded = encodePath('/a?b=c&d=e/f');
+    expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it('decodePath returns null on garbage', () => {
+    expect(decodePath('!!!not-base64!!!')).toBeNull();
+  });
+});
+
+describe('hitPathname / parseHitPathname', () => {
+  it('round-trips day, bot slug and path', () => {
+    const pathname = hitPathname(hit(), 1781254800000, 'ab12cd');
+    const parsed = parseHitPathname(pathname);
+    expect(parsed).toEqual({
+      day: '2026-06-12',
+      botSlug: 'gptbot',
+      path: '/fieldwork/10-excellent-manners',
+    });
+  });
+
+  it('caps hostile long paths before encoding (still parseable)', () => {
+    const long = '/x?q=' + 'a'.repeat(400);
+    const pathname = hitPathname(hit({ path: long }), 1781254800000, 'ab12cd');
+    expect(pathname.length).toBeLessThan(300);
+    const parsed = parseHitPathname(pathname);
+    expect(parsed?.path).toBe(long.slice(0, 140));
+  });
+
+  it('returns null for foreign pathnames', () => {
+    expect(parseHitPathname('argue-log/2026-06-12.jsonl')).toBeNull();
+    expect(parseHitPathname('crawler-hits/2026-06-12/readme.txt')).toBeNull();
+  });
+});

--- a/src/lib/stats/crawler-log/append.ts
+++ b/src/lib/stats/crawler-log/append.ts
@@ -1,0 +1,27 @@
+import { put } from '@vercel/blob';
+import { CRAWLER_HIT, hitPathname, type CrawlerHit } from './schema';
+
+/**
+ * Record one AI-crawler hit as its own Blob object.
+ *
+ * Called from middleware via `event.waitUntil` — this module must stay
+ * edge-safe (no `server-only` import, no Node-only APIs) and must never
+ * throw into the request path; callers attach a `.catch`.
+ *
+ * One object per hit means concurrent crawler requests cannot race each
+ * other (no read-modify-write).
+ */
+export async function appendCrawlerHit(hit: CrawlerHit): Promise<void> {
+  CRAWLER_HIT.parse(hit);
+  const token = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!token) throw new Error('BLOB_READ_WRITE_TOKEN missing');
+
+  const ms = Date.parse(hit.timestamp);
+  const rand = Math.random().toString(36).slice(2, 8);
+  await put(hitPathname(hit, ms, rand), JSON.stringify(hit), {
+    access: 'private',
+    contentType: 'application/json',
+    addRandomSuffix: false,
+    token,
+  });
+}

--- a/src/lib/stats/crawler-log/read.ts
+++ b/src/lib/stats/crawler-log/read.ts
@@ -1,0 +1,83 @@
+import 'server-only';
+import { list } from '@vercel/blob';
+import { CRAWLER_HIT_PREFIX, parseHitPathname } from './schema';
+import { dayKeyUtc } from '@/lib/argue-log/day';
+
+export interface CrawlerStats {
+  totalHits: number;
+  /** Display-slug → hit count, sorted desc. */
+  byBot: Array<{ botSlug: string; hits: number }>;
+  /** Oldest → newest within the window; days with zero hits included. */
+  byDay: Array<{ day: string; hits: number }>;
+  /** Most-fetched paths, sorted desc, capped at `topN`. */
+  topPaths: Array<{ path: string; hits: number }>;
+}
+
+function utcDaysBack(days: number, now: Date): string[] {
+  const out: string[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    out.push(dayKeyUtc(new Date(now.getTime() - i * 24 * 60 * 60 * 1000)));
+  }
+  return out;
+}
+
+/**
+ * Aggregate AI-crawler hits over the trailing `days` window.
+ *
+ * Works entirely from `list()` pathnames — the aggregation dimensions
+ * (day, bot, path) are encoded in each object's name, so no blob bodies
+ * are fetched (the store is private; body reads are signed round-trips).
+ * One `list()` per day keeps each call's result set small and naturally
+ * scopes the window; pagination within a day is followed via `cursor`.
+ */
+export async function readCrawlerStats(
+  days: number,
+  options: { now?: Date; topN?: number } = {},
+): Promise<CrawlerStats> {
+  const token = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!token) throw new Error('BLOB_READ_WRITE_TOKEN missing');
+  const now = options.now ?? new Date();
+  const topN = options.topN ?? 10;
+
+  const dayKeys = utcDaysBack(days, now);
+  const byBot = new Map<string, number>();
+  const byPath = new Map<string, number>();
+  const byDay: Array<{ day: string; hits: number }> = [];
+  let totalHits = 0;
+
+  for (const day of dayKeys) {
+    let dayHits = 0;
+    let cursor: string | undefined;
+    do {
+      const page = await list({
+        prefix: `${CRAWLER_HIT_PREFIX}${day}/`,
+        token,
+        cursor,
+      });
+      for (const blob of page.blobs) {
+        const parsed = parseHitPathname(blob.pathname);
+        if (!parsed) continue;
+        dayHits += 1;
+        byBot.set(parsed.botSlug, (byBot.get(parsed.botSlug) ?? 0) + 1);
+        byPath.set(parsed.path, (byPath.get(parsed.path) ?? 0) + 1);
+      }
+      cursor = page.hasMore ? page.cursor : undefined;
+    } while (cursor);
+    byDay.push({ day, hits: dayHits });
+    totalHits += dayHits;
+  }
+
+  const sortDesc = <T extends { hits: number }>(arr: T[]) =>
+    arr.sort((a, b) => b.hits - a.hits);
+
+  return {
+    totalHits,
+    byBot: sortDesc(
+      [...byBot.entries()].map(([botSlug, hits]) => ({ botSlug, hits })),
+    ),
+    byDay,
+    topPaths: sortDesc(
+      [...byPath.entries()].map(([path, hits]) => ({ path, hits })),
+    ).slice(0, topN),
+  };
+}

--- a/src/lib/stats/crawler-log/read.ts
+++ b/src/lib/stats/crawler-log/read.ts
@@ -11,6 +11,9 @@ export interface CrawlerStats {
   byDay: Array<{ day: string; hits: number }>;
   /** Most-fetched paths, sorted desc, capped at `topN`. */
   topPaths: Array<{ path: string; hits: number }>;
+  /** Fetches of /llms.txt — the "did the machines read the note we left
+   * them" number, surfaced regardless of whether it makes topN. */
+  llmsTxtHits: number;
 }
 
 function utcDaysBack(days: number, now: Date): string[] {
@@ -72,6 +75,7 @@ export async function readCrawlerStats(
 
   return {
     totalHits,
+    llmsTxtHits: byPath.get('/llms.txt') ?? 0,
     byBot: sortDesc(
       [...byBot.entries()].map(([botSlug, hits]) => ({ botSlug, hits })),
     ),

--- a/src/lib/stats/crawler-log/schema.ts
+++ b/src/lib/stats/crawler-log/schema.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+import { botSlug } from '../ai-crawlers';
+
+/**
+ * Crawler-hit log: one Blob object per AI-crawler page fetch.
+ *
+ * One-file-per-hit (not a daily JSONL) is deliberate — middleware writes
+ * are concurrent and a get-then-concat-then-put append would race (the
+ * known argue-log v1 tradeoff; this store starts on the migration path
+ * that storage.ts documents).
+ *
+ * The pathname carries the aggregation dimensions (day, bot, path) so the
+ * /stats AEO panel can be computed from a single `list()` call without
+ * fetching any blob bodies — the store is private, so every body read is
+ * a signed SDK round-trip we'd rather not multiply by hit count. The JSON
+ * body keeps the full record (exact timestamp + raw UA) for forensics.
+ *
+ * Pathname shape:
+ *   crawler-hits/YYYY-MM-DD/<bot-slug>/<ms>-<rand>_<b64url(path)>.json
+ */
+
+export const CRAWLER_HIT = z.object({
+  schema_version: z.literal(1),
+  timestamp: z.iso.datetime(),
+  bot: z.string().min(1),
+  path: z.string().min(1).max(500),
+  ua: z.string().max(300),
+});
+export type CrawlerHit = z.infer<typeof CRAWLER_HIT>;
+
+export const CRAWLER_HIT_PREFIX = 'crawler-hits/';
+
+/** Base64url without padding — pathname-safe encoding of the request path. */
+export function encodePath(path: string): string {
+  const bytes = new TextEncoder().encode(path);
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function decodePath(encoded: string): string | null {
+  try {
+    const b64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
+    const bin = atob(b64);
+    const bytes = Uint8Array.from(bin, (c) => c.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+export interface ParsedHitPathname {
+  day: string;
+  botSlug: string;
+  path: string;
+}
+
+const HIT_PATHNAME_RE = new RegExp(
+  `^${CRAWLER_HIT_PREFIX}(\\d{4}-\\d{2}-\\d{2})/([a-z0-9-]+)/\\d+-[a-z0-9]+_([A-Za-z0-9_-]*)\\.json$`,
+);
+
+/**
+ * Build the Blob pathname for one hit. `rand` keeps two same-millisecond
+ * hits from colliding; callers pass something short and lowercase.
+ */
+export function hitPathname(
+  hit: CrawlerHit,
+  ms: number,
+  rand: string,
+): string {
+  const day = hit.timestamp.slice(0, 10);
+  // Path is capped BEFORE encoding so a hostile query-string-laden URL
+  // can't blow past Blob pathname limits, and the b64 stays decodable
+  // (a post-encoding cap could cut mid-quantum). The JSON body keeps the
+  // uncapped value.
+  const encoded = encodePath(hit.path.slice(0, 140));
+  return `${CRAWLER_HIT_PREFIX}${day}/${botSlug(hit.bot)}/${ms}-${rand}_${encoded}.json`;
+}
+
+/** Parse a hit pathname back into its aggregation dimensions. Returns null
+ * for anything that doesn't match the v1 shape (schema-drift tolerant). */
+export function parseHitPathname(pathname: string): ParsedHitPathname | null {
+  const m = HIT_PATHNAME_RE.exec(pathname);
+  if (!m) return null;
+  const decoded = decodePath(m[3]);
+  // A truncated b64 tail can still decode to a usable path prefix; a fully
+  // undecodable one degrades to '(unknown)' rather than dropping the hit.
+  return { day: m[1], botSlug: m[2], path: decoded ?? '(unknown)' };
+}

--- a/src/lib/stats/search-console.ts
+++ b/src/lib/stats/search-console.ts
@@ -29,6 +29,40 @@ export interface SearchRow {
   position: number;
 }
 
+/** Queries containing Maria's name — the "do you own your own name" set.
+ * Matched per word so "maria bines site", "bines.ai", "maria ai blog" all
+ * count, but "submarine" does not. */
+const BRAND_QUERY_RE = /\b(maria|bines)\b|bines\.ai/i;
+
+export interface BrandSplit {
+  brand: SearchRow[];
+  topic: SearchRow[];
+  /** Impressions-weighted average position across brand queries, 1dp.
+   * null when there are no brand impressions yet. */
+  brandPosition: number | null;
+}
+
+/** Pure: split GSC query rows into brand (her name) vs topic queries.
+ * Exported separately so the page can render the "being found as a
+ * person" readout the AEO strategy centres on. */
+export function splitBrandQueries(rows: SearchRow[]): BrandSplit {
+  const brand: SearchRow[] = [];
+  const topic: SearchRow[] = [];
+  for (const row of rows) {
+    (BRAND_QUERY_RE.test(row.keys[0] ?? '') ? brand : topic).push(row);
+  }
+  const impressions = brand.reduce((sum, r) => sum + r.impressions, 0);
+  const brandPosition =
+    impressions > 0
+      ? Math.round(
+          (brand.reduce((sum, r) => sum + r.position * r.impressions, 0) /
+            impressions) *
+            10,
+        ) / 10
+      : null;
+  return { brand, topic, brandPosition };
+}
+
 export type SearchConsoleStats =
   | { status: 'unconfigured' }
   | { status: 'error'; message: string }

--- a/src/lib/stats/search-console.ts
+++ b/src/lib/stats/search-console.ts
@@ -1,0 +1,190 @@
+import 'server-only';
+
+/**
+ * Google Search Console read-back for the /stats SEO panel.
+ *
+ * Auth model: a Google service account added as a (restricted) user on the
+ * `sc-domain:bines.ai` Search Console property. Service-account JWTs never
+ * expire the way user OAuth refresh flows do — no re-auth ceremony, which
+ * is the right shape for a single-owner personal site.
+ *
+ * Env:
+ *   GSC_CLIENT_EMAIL  service account email
+ *   GSC_PRIVATE_KEY   PKCS#8 PEM; literal `\n` sequences are tolerated
+ *                     (Vercel env vars flatten newlines)
+ *
+ * No googleapis dependency — the JWT is signed with WebCrypto (RS256) and
+ * the two HTTP calls are plain fetch. ~60 lines beats a 100MB SDK.
+ */
+
+const PROPERTY = 'sc-domain:bines.ai';
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const SCOPE = 'https://www.googleapis.com/auth/webmasters.readonly';
+
+export interface SearchRow {
+  keys: string[];
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+}
+
+export type SearchConsoleStats =
+  | { status: 'unconfigured' }
+  | { status: 'error'; message: string }
+  | {
+      status: 'ok';
+      totals: { clicks: number; impressions: number; position: number | null };
+      queries: SearchRow[];
+      pages: SearchRow[];
+    };
+
+function b64url(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function pemToPkcs8(pem: string): Uint8Array {
+  const body = pem
+    .replace(/\\n/g, '\n')
+    .replace(/-----(BEGIN|END) PRIVATE KEY-----/g, '')
+    .replace(/\s+/g, '');
+  return Uint8Array.from(atob(body), (c) => c.charCodeAt(0));
+}
+
+async function signJwt(
+  clientEmail: string,
+  privateKeyPem: string,
+  now: Date,
+): Promise<string> {
+  const header = b64url(
+    new TextEncoder().encode(JSON.stringify({ alg: 'RS256', typ: 'JWT' })),
+  );
+  const iat = Math.floor(now.getTime() / 1000);
+  const claims = b64url(
+    new TextEncoder().encode(
+      JSON.stringify({
+        iss: clientEmail,
+        scope: SCOPE,
+        aud: TOKEN_URL,
+        iat,
+        exp: iat + 3600,
+      }),
+    ),
+  );
+  const signingInput = `${header}.${claims}`;
+  const key = await crypto.subtle.importKey(
+    'pkcs8',
+    pemToPkcs8(privateKeyPem).buffer as ArrayBuffer,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    key,
+    new TextEncoder().encode(signingInput),
+  );
+  return `${signingInput}.${b64url(new Uint8Array(sig))}`;
+}
+
+async function accessToken(
+  clientEmail: string,
+  privateKeyPem: string,
+  now: Date,
+): Promise<string> {
+  const assertion = await signJwt(clientEmail, privateKeyPem, now);
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion,
+    }),
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    throw new Error(`token exchange failed: ${res.status}`);
+  }
+  const json = (await res.json()) as { access_token?: string };
+  if (!json.access_token) throw new Error('token exchange returned no token');
+  return json.access_token;
+}
+
+async function searchAnalyticsQuery(
+  token: string,
+  body: Record<string, unknown>,
+): Promise<SearchRow[]> {
+  const url = `https://www.googleapis.com/webmasters/v3/sites/${encodeURIComponent(PROPERTY)}/searchAnalytics/query`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    throw new Error(`searchAnalytics query failed: ${res.status}`);
+  }
+  const json = (await res.json()) as { rows?: SearchRow[] };
+  return json.rows ?? [];
+}
+
+/**
+ * Fetch SEO performance for the trailing `days` window (GSC data lags
+ * ~2 days; the window is shifted back accordingly so the tail isn't a
+ * misleading dip of not-yet-processed days).
+ */
+export async function readSearchConsoleStats(
+  days: number,
+  options: { now?: Date } = {},
+): Promise<SearchConsoleStats> {
+  const clientEmail = process.env.GSC_CLIENT_EMAIL;
+  const privateKey = process.env.GSC_PRIVATE_KEY;
+  if (!clientEmail || !privateKey) return { status: 'unconfigured' };
+
+  const now = options.now ?? new Date();
+  const dayMs = 24 * 60 * 60 * 1000;
+  const end = new Date(now.getTime() - 2 * dayMs);
+  const start = new Date(end.getTime() - days * dayMs);
+  const range = {
+    startDate: start.toISOString().slice(0, 10),
+    endDate: end.toISOString().slice(0, 10),
+  };
+
+  try {
+    const token = await accessToken(clientEmail, privateKey, now);
+    const [totalRows, queries, pages] = await Promise.all([
+      searchAnalyticsQuery(token, { ...range }),
+      searchAnalyticsQuery(token, {
+        ...range,
+        dimensions: ['query'],
+        rowLimit: 15,
+      }),
+      searchAnalyticsQuery(token, {
+        ...range,
+        dimensions: ['page'],
+        rowLimit: 10,
+      }),
+    ]);
+    const total = totalRows[0];
+    return {
+      status: 'ok',
+      totals: {
+        clicks: total?.clicks ?? 0,
+        impressions: total?.impressions ?? 0,
+        position: total ? Math.round(total.position * 10) / 10 : null,
+      },
+      queries,
+      pages,
+    };
+  } catch (err) {
+    return {
+      status: 'error',
+      message: err instanceof Error ? err.message : 'unknown error',
+    };
+  }
+}

--- a/src/lib/stats/vercel-analytics.ts
+++ b/src/lib/stats/vercel-analytics.ts
@@ -1,5 +1,5 @@
 import 'server-only';
-import { identifyAiReferrer } from './ai-crawlers';
+import { identifyAiReferrer, identifySocialReferrer } from './ai-crawlers';
 
 /**
  * Read-back from Vercel Web Analytics for the /stats visits panel.
@@ -27,7 +27,12 @@ export interface VisitStats {
   bounceRate: number | null;
   timeSeries: Array<{ date: string; views: number }>;
   topPages: Array<{ path: string; views: number }>;
-  referrers: Array<{ source: string; views: number; aiSurface: string | null }>;
+  referrers: Array<{
+    source: string;
+    views: number;
+    aiSurface: string | null;
+    socialSurface: string | null;
+  }>;
 }
 
 interface VercelEnv {
@@ -115,6 +120,7 @@ export async function readVisitStats(
         source,
         views: Number(d.total ?? 0),
         aiSurface: identifyAiReferrer(source),
+        socialSurface: identifySocialReferrer(source),
       };
     }),
   };

--- a/src/lib/stats/vercel-analytics.ts
+++ b/src/lib/stats/vercel-analytics.ts
@@ -1,0 +1,121 @@
+import 'server-only';
+import { identifyAiReferrer } from './ai-crawlers';
+
+/**
+ * Read-back from Vercel Web Analytics for the /stats visits panel.
+ *
+ * Collection (the <Analytics /> script in layout.tsx) and read-back are
+ * separate systems. These are the same endpoints the Vercel dashboard
+ * uses — NOT part of the documented public REST API, so shapes can drift.
+ * Verified working on the Morgan site (1 Jun 2026):
+ *   overview   → { total, devices, bounceRate }          (range totals)
+ *   timeseries → { data: { groups: { all: [{ key, total, devices }] } } }
+ *   stats      → { data: [{ key, total, devices }] }     (type=path|referrer)
+ * All three 404 without a `teamId` query param.
+ *
+ * Every fetch is `no-store`: /stats is a single-viewer admin page, so live
+ * round-trips per view are cheaper than cache-staleness bookkeeping. When
+ * the endpoints fail (token revoked, Vercel locks them down) we return
+ * `unavailable: true` rather than zeros — a confident "0 page views" would
+ * read as "no traffic" when the truth is "couldn't reach the data".
+ */
+
+export interface VisitStats {
+  unavailable: boolean;
+  pageViews: number | null;
+  visitors: number | null;
+  bounceRate: number | null;
+  timeSeries: Array<{ date: string; views: number }>;
+  topPages: Array<{ path: string; views: number }>;
+  referrers: Array<{ source: string; views: number; aiSurface: string | null }>;
+}
+
+interface VercelEnv {
+  token: string;
+  projectId: string;
+  teamId: string;
+}
+
+function vercelEnv(): VercelEnv | null {
+  const token = process.env.VERCEL_API_TOKEN;
+  const projectId = process.env.VERCEL_PROJECT_ID;
+  const teamId = process.env.VERCEL_TEAM_ID;
+  if (!token || !projectId || !teamId) return null;
+  return { token, projectId, teamId };
+}
+
+const BASE_URL = 'https://vercel.com/api/web-analytics';
+
+async function getJson(url: string, token: string): Promise<unknown | null> {
+  try {
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: 'no-store',
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch visit stats for the trailing `days` window.
+ * Returns null when the three VERCEL_* env vars are not configured —
+ * the page renders an honest "not configured" state for that.
+ */
+export async function readVisitStats(
+  days: number,
+  options: { now?: Date } = {},
+): Promise<VisitStats | null> {
+  const env = vercelEnv();
+  if (!env) return null;
+
+  const now = options.now ?? new Date();
+  const from = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+  const params = new URLSearchParams({
+    projectId: env.projectId,
+    teamId: env.teamId,
+    from: from.toISOString(),
+    to: now.toISOString(),
+    environment: 'production',
+  });
+
+  const [overview, series, pages, referrers] = (await Promise.all([
+    getJson(`${BASE_URL}/overview?${params}`, env.token),
+    getJson(`${BASE_URL}/timeseries?${params}`, env.token),
+    getJson(`${BASE_URL}/stats?${params}&type=path&limit=10`, env.token),
+    getJson(`${BASE_URL}/stats?${params}&type=referrer&limit=20`, env.token),
+    // Shapes are upstream-controlled and undocumented; parsed defensively below.
+  ])) as Array<Record<string, any> | null>; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  const unavailable = !overview && !series && !pages && !referrers;
+
+  const seriesRows: Array<Record<string, unknown>> =
+    series?.data?.groups?.all ?? [];
+  const pageRows: Array<Record<string, unknown>> = pages?.data ?? [];
+  const referrerRows: Array<Record<string, unknown>> = referrers?.data ?? [];
+
+  return {
+    unavailable,
+    pageViews: unavailable ? null : Number(overview?.total ?? 0),
+    visitors: unavailable ? null : Number(overview?.devices ?? 0),
+    bounceRate: unavailable ? null : Number(overview?.bounceRate ?? 0),
+    timeSeries: seriesRows.map((d) => ({
+      date: String(d.key ?? ''),
+      views: Number(d.total ?? 0),
+    })),
+    topPages: pageRows.map((d) => ({
+      path: String(d.key ?? ''),
+      views: Number(d.total ?? 0),
+    })),
+    referrers: referrerRows.map((d) => {
+      const source = String(d.key ?? '');
+      return {
+        source,
+        views: Number(d.total ?? 0),
+        aiSurface: identifyAiReferrer(source),
+      };
+    }),
+  };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
+import type { NextFetchEvent, NextRequest } from 'next/server';
+import { identifyAiCrawler } from '@/lib/stats/ai-crawlers';
+import { appendCrawlerHit } from '@/lib/stats/crawler-log/append';
 
 /**
  * User-Agent substrings of bots that ignore robots.txt's disallow directive.
@@ -59,7 +61,7 @@ function unauthorized(): NextResponse {
 }
 
 /**
- * HTTP Basic Auth gate for /argue/log. Reads `ARGUE_LOG_PASSWORD` from
+ * HTTP Basic Auth gate for admin routes (ADMIN_PATHS). Reads `ARGUE_LOG_PASSWORD` from
  * the environment; fail-closed (503) if unconfigured. Username is ignored
  * — the password alone is the secret. Returns null when the request is
  * authorised; returns a 401 response otherwise.
@@ -91,16 +93,19 @@ function checkAdminAuth(req: NextRequest): NextResponse | null {
   return null;
 }
 
-export function middleware(req: NextRequest): NextResponse {
+/** Admin-only path prefixes — basic auth gate (shared ARGUE_LOG_PASSWORD). */
+const ADMIN_PATHS = ['/argue/log', '/stats'];
+
+export function middleware(req: NextRequest, event: NextFetchEvent): NextResponse {
   const path = req.nextUrl.pathname;
 
-  // /argue/log and any sub-path is admin-only — basic auth gate.
-  if (path === '/argue/log' || path.startsWith('/argue/log/')) {
+  if (ADMIN_PATHS.some((p) => path === p || path.startsWith(`${p}/`))) {
     const denied = checkAdminAuth(req);
     if (denied) return denied;
   }
 
-  const ua = (req.headers.get('user-agent') ?? '').toLowerCase();
+  const rawUa = req.headers.get('user-agent') ?? '';
+  const ua = rawUa.toLowerCase();
   if (ua && BLOCKED_BOT_UA.some((needle) => ua.includes(needle))) {
     return new NextResponse(SNARK, {
       status: 403,
@@ -112,6 +117,26 @@ export function middleware(req: NextRequest): NextResponse {
       },
     });
   }
+
+  // AEO signal: invited AI crawlers don't run the client analytics script,
+  // so they're invisible to Vercel Web Analytics. Log their page fetches to
+  // Blob for the /stats AEO panel. Fire-and-forget after the response — a
+  // logging failure must never break a crawler's (or anyone's) request.
+  const bot = identifyAiCrawler(rawUa);
+  if (bot && !path.startsWith('/api/')) {
+    event.waitUntil(
+      appendCrawlerHit({
+        schema_version: 1,
+        timestamp: new Date().toISOString(),
+        bot,
+        path: path.slice(0, 500),
+        ua: rawUa.slice(0, 300),
+      }).catch(() => {
+        // Swallowed by design — observability must not affect availability.
+      }),
+    );
+  }
+
   return NextResponse.next();
 }
 


### PR DESCRIPTION
## What

A private, Basic-auth-gated `/stats` dashboard (same `ARGUE_LOG_PASSWORD` gate as `/argue/log`), plus the collection wiring it reads from:

- **Visits** — mounts `<Analytics />` (the `@vercel/analytics` dep was installed but never wired, so nothing was being collected). Read-back uses the same dashboard endpoints proven on the Morgan site; needs `VERCEL_API_TOKEN` / `VERCEL_PROJECT_ID` / `VERCEL_TEAM_ID` env vars.
- **Argue (the chatbot)** — aggregates the existing argue-log Blob JSONL: conversations, exchanges, refusals, which pieces people argue from, models.
- **AEO** — middleware now logs invited AI-crawler fetches (GPTBot, ClaudeBot, PerplexityBot…) to Blob, one object per hit with day/bot/path encoded in the pathname so aggregation is a `list()` with no body reads. Plus AI-surface referrals (ChatGPT/Perplexity/Copilot…) tagged in the referrer table.
- **SEO** — Google Search Console via service-account JWT signed with WebCrypto (no googleapis dep). Shows an honest "not connected" state until `GSC_CLIENT_EMAIL`/`GSC_PRIVATE_KEY` land.

Every panel has an honest unconfigured/unavailable state — no confident zeros when a data source is unreachable.

## Verification

- Gates: typecheck, lint, **636 tests**, build — all green
- Eyes-on render check on a local dev server (fresh, port checked first, killed after): page renders in the site shell, real argue data showing, 401 without auth / 200 with
- `/security-review` run on the branch (middleware + env handling touched): **no findings** — auth matcher coverage, blob pathname encoding, XSS sinks, SSRF and JWT construction all examined and cleared
- `/stats` is noindexed, absent from the sitemap, linked from nowhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)