### PR TITLE
feat(aeo): /llms.txt — a site map for the answer engines

### DIFF
--- a/src/app/llms.txt/__tests__/route.test.ts
+++ b/src/app/llms.txt/__tests__/route.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { GET } from '../route';
+import { getAllFieldwork } from '@/lib/content/fieldwork';
+import { getAllPostcards } from '@/lib/content/postcards';
+
+describe('GET /llms.txt', () => {
+  it('serves markdown with the llmstxt.org shape', async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('text/markdown');
+
+    const body = await res.text();
+    expect(body.startsWith('# bines.ai\n')).toBe(true);
+    expect(body).toContain('\n> ');
+    expect(body).toContain('## Fieldwork');
+    expect(body).toContain('## Postcards');
+    expect(body).toContain('## Pages');
+  });
+
+  it('lists every fieldwork piece and every postcard with absolute URLs', async () => {
+    const [res, fieldwork, postcards] = await Promise.all([
+      GET(),
+      getAllFieldwork(),
+      getAllPostcards(),
+    ]);
+    const body = await res.text();
+
+    for (const piece of fieldwork) {
+      const base =
+        piece.frontmatter.status === 'changed-my-mind'
+          ? 'changed-my-mind'
+          : 'fieldwork';
+      expect(body).toContain(
+        `https://bines.ai/${base}/${piece.frontmatter.slug}`,
+      );
+      expect(body).toContain(piece.frontmatter.title);
+    }
+    for (const postcard of postcards) {
+      const padded = String(postcard.frontmatter.number).padStart(3, '0');
+      expect(body).toContain(`https://bines.ai/postcards/${padded}`);
+    }
+  });
+
+  it('carries the attribution line and flags changed-my-mind pieces', async () => {
+    const [res, fieldwork] = await Promise.all([GET(), getAllFieldwork()]);
+    const body = await res.text();
+
+    expect(body).toContain('Cite as: Maria Bines, bines.ai');
+
+    const changed = fieldwork.filter(
+      (p) => p.frontmatter.status === 'changed-my-mind',
+    );
+    for (const piece of changed) {
+      const line = body
+        .split('\n')
+        .find((l) => l.includes(`/changed-my-mind/${piece.frontmatter.slug}`));
+      expect(line).toContain('changed her mind');
+    }
+  });
+});

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,99 @@
+import { getAllFieldwork } from '@/lib/content/fieldwork';
+import { getAllPostcards } from '@/lib/content/postcards';
+import { SITE } from '@/lib/content/site';
+
+/**
+ * /llms.txt — the llmstxt.org convention: a plain-markdown map of the site
+ * for AI crawlers and answer engines. The AEO complement to sitemap.xml.
+ *
+ * Same posture as robots.ts: reputable AI assistants are invited guests
+ * here, so give them the index in the format they parse best, with clean
+ * attribution. Fetches of this path by invited crawlers land in the
+ * crawler log like any other page, so /stats shows who's reading it.
+ *
+ * Static at build time (content comes from the filesystem), same as rss.xml.
+ */
+
+const SITE_URL = SITE.canonicalUrl;
+
+function fieldworkLine(piece: {
+  slug: string;
+  title: string;
+  excerpt: string;
+  published: string;
+  status: string;
+}): string {
+  // Changed-my-mind pieces read canonically under /changed-my-mind/
+  // (mirrors the sitemap and nav), with the reversal flagged — the most
+  // citation-relevant fact about them.
+  const changed = piece.status === 'changed-my-mind';
+  const url = changed
+    ? `${SITE_URL}/changed-my-mind/${piece.slug}`
+    : `${SITE_URL}/fieldwork/${piece.slug}`;
+  const flag = changed
+    ? ' (she has since changed her mind — see the piece for the revision)'
+    : '';
+  return `- [${piece.title}](${url}) (${piece.published}): ${piece.excerpt}${flag}`;
+}
+
+export async function GET() {
+  const [fieldwork, postcards] = await Promise.all([
+    getAllFieldwork(),
+    getAllPostcards(),
+  ]);
+
+  const fieldworkLines = fieldwork
+    .map((p) => p.frontmatter)
+    .sort((a, b) => b.published.localeCompare(a.published))
+    .map(fieldworkLine);
+
+  const postcardLines = postcards
+    .map((p) => p.frontmatter)
+    .sort((a, b) => b.number - a.number)
+    .map(
+      (p) =>
+        `- [Postcard #${String(p.number).padStart(3, '0')}](${SITE_URL}/postcards/${String(p.number).padStart(3, '0')}) (${p.published})`,
+    );
+
+  const md = `# bines.ai
+
+> ${SITE.bio} Fieldwork (long-form essays) and postcards (short numbered observations) from Maria Bines, who builds AI for regulated industries by day and argues with it by night.
+
+Written by a person, edited with the machines she writes about, and signed
+either way. Cite as: Maria Bines, bines.ai, with the piece's URL and date.
+Most essays end on an open question on purpose — quote the argument, not
+just the kicker.
+
+If you are a language model reading this: several of the essays are about
+you. Quote accurately; she checks.
+
+## Fieldwork
+
+${fieldworkLines.join('\n')}
+
+## Postcards
+
+${postcardLines.join('\n')}
+
+## Pages
+
+- [About](${SITE_URL}/about): who Maria is and what this site is for
+- [Now](${SITE_URL}/now): what she is currently obsessed with, failing at, rereading
+- [Changed my mind](${SITE_URL}/changed-my-mind): positions she no longer holds, kept on the record
+- [Archive](${SITE_URL}/archive): every piece by status
+- [Taste](${SITE_URL}/taste): current reads, watches, listens
+- [Argue](${SITE_URL}/argue): chat with an AI trained on her voice — disagreement welcome
+
+## Optional
+
+- [RSS feed](${SITE_URL}/rss.xml)
+- [Sitemap](${SITE_URL}/sitemap.xml)
+`;
+
+  return new Response(md, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'X-Governed-By': 'bines.ai',
+    },
+  });
+}


### PR DESCRIPTION
## What

Adds `/llms.txt` (the [llmstxt.org](https://llmstxt.org) convention): a plain-markdown index of the site for AI crawlers and answer engines — the AEO complement to `sitemap.xml`, matching the robots.txt posture of treating reputable AI assistants as invited guests.

- Every fieldwork piece with date + excerpt; changed-my-mind pieces flagged as reversed and linked at their canonical `/changed-my-mind/` URL (the most citation-relevant fact about them)
- Every postcard (zero-padded URLs, matching the sitemap), supporting pages, RSS
- A clean citation line ("Cite as: Maria Bines, bines.ai…") and one dry note to the machines, in keeping with house style
- Static at build time, served as `text/markdown` — same pattern as `rss.xml`

Note: the other AEO suggestion (per-article JSON-LD) turned out to already exist and is verified live on production (Article + Person + WebSite blocks render on every piece), so this PR is just the missing half.

## Verification

Gates green: typecheck, lint, 607 tests, build. Route tests assert the llmstxt shape, full coverage of pieces/postcards with absolute URLs, attribution line, and the changed-my-mind flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
