### PR TITLE
chore: resolve advisory review items from PRs #57/#58

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -68,8 +68,7 @@ export default function RootLayout({
         <JsonLd data={websiteJsonLd()} />
         <JsonLd data={personJsonLd()} />
         <PageShell>{children}</PageShell>
-        {/* Vercel Web Analytics collection script. Cookieless, no consent
-            banner required. Read-back lives at /stats (admin-only). */}
+        {/* Cookieless — no consent banner required. */}
         <Analytics />
       </body>
     </html>

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -11,7 +11,8 @@ import { SITE } from '@/lib/content/site';
  * attribution. Fetches of this path by invited crawlers land in the
  * crawler log like any other page, so /stats shows who's reading it.
  *
- * Static at build time (content comes from the filesystem), same as rss.xml.
+ * Rendered per request like rss.xml (Next 15 route handlers are dynamic by
+ * default) — fine, it's a filesystem read.
  */
 
 const SITE_URL = SITE.canonicalUrl;

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -13,16 +13,11 @@ import {
 /**
  * /stats — Maria's private analytics dashboard.
  *
- * Four panels, each with an honest empty/unconfigured state (a panel that
- * can't reach its data says so — it never shows a confident zero):
- *   visits  — Vercel Web Analytics read-back (sapphire)
- *   argue   — chat usage aggregated from the argue-log (ruby)
- *   aeo     — invited AI-crawler fetches + AI-surface referrals (amethyst)
- *   seo     — Google Search Console performance (emerald)
- *
- * Gated by Basic auth in middleware.ts (shared ARGUE_LOG_PASSWORD), hidden
- * from robots, absent from the sitemap, linked from nowhere. Server-rendered
- * HTML only — no client JavaScript, charts are CSS bars.
+ * Two invariants the code can't show on its own: every panel must keep an
+ * honest unconfigured/unavailable state (never a confident zero when the
+ * data source is unreachable), and the page must render with no client
+ * JavaScript (site-wide rule) — hence CSS bars, not a chart library.
+ * Auth lives in middleware.ts (ADMIN_PATHS), not here.
  */
 
 export const metadata: Metadata = {

--- a/src/lib/stats/ai-crawlers.ts
+++ b/src/lib/stats/ai-crawlers.ts
@@ -1,14 +1,8 @@
 /**
- * AI crawler + AI referrer identification for the AEO panel on /stats.
+ * Pure, no env, no I/O — must stay safe to import from edge middleware.
  *
- * Pure, no env, no I/O — safe to import from middleware (edge) and from
- * server components alike.
- *
- * The crawler table mirrors the *invited* AI bots in src/app/robots.ts.
- * If a bot is added or removed there, update this table in the same PR
- * (the /stats AEO panel counts only bots we have chosen to welcome —
- * blocked scrapers get a 403 in middleware and are deliberately not part
- * of the answer-engine story).
+ * The crawler table mirrors the *invited* AI bots in src/app/robots.ts;
+ * if a bot is added or removed there, update this table in the same PR.
  */
 
 /** UA substring (lowercase) → display name shown on /stats. Order matters:

--- a/src/lib/stats/argue-stats.ts
+++ b/src/lib/stats/argue-stats.ts
@@ -1,8 +1,6 @@
 import type { ArgueLogEntry } from '@/lib/argue-log/schema';
 
 /**
- * Aggregation over argue-log entries for the /stats chat panel.
- *
  * The pure aggregator is separated from the Blob-reading loader so it can
  * be unit-tested without storage mocks. Loading lives in the page (it
  * composes readArgueLogDay, which is already tested in argue-log).

--- a/src/lib/stats/search-console.ts
+++ b/src/lib/stats/search-console.ts
@@ -164,7 +164,12 @@ async function searchAnalyticsQuery(
     throw new Error(`searchAnalytics query failed: ${res.status}`);
   }
   const json = (await res.json()) as { rows?: SearchRow[] };
-  return json.rows ?? [];
+  // GSC can return null position on zero-impression rows; normalise at the
+  // parse boundary so downstream arithmetic never sees a non-number.
+  return (json.rows ?? []).map((r) => ({
+    ...r,
+    position: typeof r.position === 'number' ? r.position : 0,
+  }));
 }
 
 /**

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -93,7 +93,6 @@ function checkAdminAuth(req: NextRequest): NextResponse | null {
   return null;
 }
 
-/** Admin-only path prefixes — basic auth gate (shared ARGUE_LOG_PASSWORD). */
 const ADMIN_PATHS = ['/argue/log', '/stats'];
 
 export function middleware(req: NextRequest, event: NextFetchEvent): NextResponse {


### PR DESCRIPTION
Closes out the review bot's advisory COMMENT items now that both features are merged:

- **Comment verbosity**: trimmed the flagged WHAT-comments to their non-obvious invariants (the honest-empty-state contract, the no-client-JS rule, edge-import safety, the robots.ts sync constraint)
- **`SearchRow.position` nullability** (real latent gap): GSC can return null position; now normalised to a number at the parse boundary so downstream arithmetic is safe
- **llms.txt docstring accuracy**: corrected the static-at-build claim — Next 15 route handlers are dynamic by default, matching rss.xml

The `globalThis.fetch` test-stub flag and the `eslint-disable` were accepted with reasoning on the PR #57 thread.

Gates green: typecheck, lint, 644 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)