### PR TITLE
feat(stats): GSC auth via OAuth refresh token (org policy blocks SA keys)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ The phase workflow (concept → context → architecture → assessment → stor
 
 - **Collection**: Vercel Web Analytics (`<Analytics />` in `layout.tsx`, cookieless) + AI-crawler hit logging in `middleware.ts` (invited bots only, one Blob object per hit under `crawler-hits/`).
 - **Read-back**: `/stats` — private dashboard (visits / argue usage / AEO / SEO), server-rendered, no client JS. Gated by the same Basic-auth as `/argue/log` (`ARGUE_LOG_PASSWORD`). Library code in `src/lib/stats/`.
-- **Env vars**: `VERCEL_API_TOKEN` + `VERCEL_PROJECT_ID` + `VERCEL_TEAM_ID` (visits panel; undocumented dashboard endpoints — shapes pinned in `vercel-analytics.ts`), `GSC_CLIENT_EMAIL` + `GSC_PRIVATE_KEY` (Search Console service account, property `sc-domain:bines.ai`). Every panel has an honest unconfigured/unavailable state — never render a confident zero when the data source is unreachable.
+- **Env vars**: `VERCEL_API_TOKEN` + `VERCEL_PROJECT_ID` + `VERCEL_TEAM_ID` (visits panel; undocumented dashboard endpoints — shapes pinned in `vercel-analytics.ts`), `GSC_CLIENT_ID` + `GSC_CLIENT_SECRET` + `GSC_REFRESH_TOKEN` (Search Console via OAuth refresh token from Maria's account — service-account keys are blocked by her Google org policy; property `sc-domain:bines.ai`). Every panel has an honest unconfigured/unavailable state — never render a confident zero when the data source is unreachable.
 
 ## PR review flow
 

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -348,8 +348,8 @@ function SeoPanel({ seo }: { seo: SearchConsoleStats }) {
   if (seo.status === 'unconfigured') {
     return (
       <Unavailable>
-        not connected — verify bines.ai in Google Search Console, then set
-        GSC_CLIENT_EMAIL and GSC_PRIVATE_KEY.
+        not connected — set GSC_CLIENT_ID, GSC_CLIENT_SECRET and
+        GSC_REFRESH_TOKEN (one-time OAuth consent from the property owner).
       </Unavailable>
     );
   }

--- a/src/lib/stats/__tests__/search-console.test.ts
+++ b/src/lib/stats/__tests__/search-console.test.ts
@@ -1,30 +1,18 @@
-// @vitest-environment node
-//
-// The JWT signing path needs a real crypto.subtle. jsdom doesn't provide
-// one, and stubbing the `crypto` global works on some Node versions and
-// not others (passed locally on 24, failed on CI's 20). Running this one
-// file in the node environment uses Node's native WebCrypto — the same
-// global the code sees in production — with no stubbing at all.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { generateKeyPairSync } from 'node:crypto';
 import {
   readSearchConsoleStats,
   splitBrandQueries,
   type SearchRow,
 } from '../search-console';
 
-const ORIG_EMAIL = process.env.GSC_CLIENT_EMAIL;
-const ORIG_KEY = process.env.GSC_PRIVATE_KEY;
+const ENV_KEYS = [
+  'GSC_CLIENT_ID',
+  'GSC_CLIENT_SECRET',
+  'GSC_REFRESH_TOKEN',
+] as const;
+const ORIG = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
 
 const NOW = new Date('2026-06-12T12:00:00.000Z');
-
-// A real (throwaway) RSA key so the WebCrypto RS256 signing path runs for
-// real — only the network is mocked.
-const { privateKey: TEST_PEM } = generateKeyPairSync('rsa', {
-  modulusLength: 2048,
-  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
-  publicKeyEncoding: { type: 'spki', format: 'pem' },
-});
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -34,29 +22,28 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 beforeEach(() => {
-  process.env.GSC_CLIENT_EMAIL = 'stats@test-project.iam.gserviceaccount.com';
-  // Vercel env vars flatten newlines to literal \n — exercise that path.
-  process.env.GSC_PRIVATE_KEY = TEST_PEM.replace(/\n/g, '\\n');
+  process.env.GSC_CLIENT_ID = 'test-client.apps.googleusercontent.com';
+  process.env.GSC_CLIENT_SECRET = 'test-secret';
+  process.env.GSC_REFRESH_TOKEN = '1//test-refresh-token';
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
-  if (ORIG_EMAIL === undefined) delete process.env.GSC_CLIENT_EMAIL;
-  else process.env.GSC_CLIENT_EMAIL = ORIG_EMAIL;
-  if (ORIG_KEY === undefined) delete process.env.GSC_PRIVATE_KEY;
-  else process.env.GSC_PRIVATE_KEY = ORIG_KEY;
+  for (const k of ENV_KEYS) {
+    if (ORIG[k] === undefined) delete process.env[k];
+    else process.env[k] = ORIG[k];
+  }
 });
 
 describe('readSearchConsoleStats', () => {
-  it('returns unconfigured when env vars are absent', async () => {
-    delete process.env.GSC_CLIENT_EMAIL;
-    delete process.env.GSC_PRIVATE_KEY;
+  it('returns unconfigured when any of the three env vars is absent', async () => {
+    delete process.env.GSC_REFRESH_TOKEN;
     expect(await readSearchConsoleStats(28, { now: NOW })).toEqual({
       status: 'unconfigured',
     });
   });
 
-  it('signs a JWT, exchanges it, and maps the three queries', async () => {
+  it('exchanges the refresh token and maps the three queries', async () => {
     const row = (keys: string[] | undefined, impressions: number) => ({
       ...(keys ? { keys } : {}),
       clicks: 3,
@@ -64,27 +51,36 @@ describe('readSearchConsoleStats', () => {
       ctr: 0.1,
       position: 7.43,
     });
-    const fetchMock = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
-      const u = String(url);
-      if (u.includes('oauth2.googleapis.com/token')) {
-        const body = String(init?.body);
-        expect(body).toContain('jwt-bearer');
-        // assertion=<header>.<claims>.<sig>
-        expect(body.split('assertion=')[1].split('.').length).toBe(3);
-        return jsonResponse({ access_token: 'ya29.test' });
-      }
-      expect(u).toContain(encodeURIComponent('sc-domain:bines.ai'));
-      const body = JSON.parse(String(init?.body)) as {
-        dimensions?: string[];
-      };
-      if (!body.dimensions) return jsonResponse({ rows: [row(undefined, 200)] });
-      if (body.dimensions[0] === 'query') {
-        return jsonResponse({ rows: [row(['boring ai'], 120)] });
-      }
-      return jsonResponse({
-        rows: [row(['https://bines.ai/fieldwork/10-excellent-manners'], 80)],
-      });
-    });
+    const fetchMock = vi.fn(
+      async (url: RequestInfo | URL, init?: RequestInit) => {
+        const u = String(url);
+        if (u.includes('oauth2.googleapis.com/token')) {
+          const body = new URLSearchParams(String(init?.body));
+          expect(body.get('grant_type')).toBe('refresh_token');
+          expect(body.get('refresh_token')).toBe('1//test-refresh-token');
+          expect(body.get('client_id')).toBe(
+            'test-client.apps.googleusercontent.com',
+          );
+          return jsonResponse({ access_token: 'ya29.test' });
+        }
+        expect(u).toContain(encodeURIComponent('sc-domain:bines.ai'));
+        expect(
+          (init?.headers as Record<string, string>).Authorization,
+        ).toBe('Bearer ya29.test');
+        const body = JSON.parse(String(init?.body)) as {
+          dimensions?: string[];
+        };
+        if (!body.dimensions) {
+          return jsonResponse({ rows: [row(undefined, 200)] });
+        }
+        if (body.dimensions[0] === 'query') {
+          return jsonResponse({ rows: [row(['boring ai'], 120)] });
+        }
+        return jsonResponse({
+          rows: [row(['https://bines.ai/fieldwork/10-excellent-manners'], 80)],
+        });
+      },
+    );
     vi.stubGlobal('fetch', fetchMock);
 
     const stats = await readSearchConsoleStats(28, { now: NOW });
@@ -103,7 +99,7 @@ describe('readSearchConsoleStats', () => {
   it('returns an error status when the token exchange fails', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => jsonResponse({ error: 'invalid_grant' }, 403)),
+      vi.fn(async () => jsonResponse({ error: 'invalid_grant' }, 400)),
     );
     const stats = await readSearchConsoleStats(28, { now: NOW });
     expect(stats.status).toBe('error');
@@ -131,10 +127,33 @@ describe('readSearchConsoleStats', () => {
     });
     expect(stats.queries).toEqual([]);
   });
+
+  it('normalises a null position from GSC to a number at the parse boundary', async () => {
+    const fetchMock = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url).includes('oauth2.googleapis.com/token')) {
+        return jsonResponse({ access_token: 'ya29.test' });
+      }
+      return jsonResponse({
+        rows: [
+          { keys: ['x'], clicks: 0, impressions: 0, ctr: 0, position: null },
+        ],
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const stats = await readSearchConsoleStats(28, { now: NOW });
+    expect(stats.status).toBe('ok');
+    if (stats.status !== 'ok') return;
+    expect(stats.queries[0].position).toBe(0);
+  });
 });
 
 describe('splitBrandQueries', () => {
-  const row = (q: string, impressions: number, position: number): SearchRow => ({
+  const row = (
+    q: string,
+    impressions: number,
+    position: number,
+  ): SearchRow => ({
     keys: [q],
     clicks: 1,
     impressions,

--- a/src/lib/stats/search-console.ts
+++ b/src/lib/stats/search-console.ts
@@ -3,23 +3,25 @@ import 'server-only';
 /**
  * Google Search Console read-back for the /stats SEO panel.
  *
- * Auth model: a Google service account added as a (restricted) user on the
- * `sc-domain:bines.ai` Search Console property. Service-account JWTs never
- * expire the way user OAuth refresh flows do — no re-auth ceremony, which
- * is the right shape for a single-owner personal site.
+ * Auth model: OAuth refresh token from Maria's own Google account (the
+ * Search Console property owner). The service-account path was the first
+ * choice but Google's Secure-by-Default org policy
+ * (iam.disableServiceAccountKeyCreation) blocks key downloads on her org —
+ * refresh tokens need no key file, so there is nothing for the policy to
+ * block. Same pattern as the Morgan site.
  *
  * Env:
- *   GSC_CLIENT_EMAIL  service account email
- *   GSC_PRIVATE_KEY   PKCS#8 PEM; literal `\n` sequences are tolerated
- *                     (Vercel env vars flatten newlines)
+ *   GSC_CLIENT_ID      OAuth client (Desktop app) id
+ *   GSC_CLIENT_SECRET  its secret
+ *   GSC_REFRESH_TOKEN  one-time consent grant, webmasters.readonly scope
  *
- * No googleapis dependency — the JWT is signed with WebCrypto (RS256) and
- * the two HTTP calls are plain fetch. ~60 lines beats a 100MB SDK.
+ * No googleapis dependency — two plain fetches beat a 100MB SDK.
  */
 
+// The refresh token must carry the webmasters.readonly scope — granted at
+// consent time, not requested here.
 const PROPERTY = 'sc-domain:bines.ai';
 const TOKEN_URL = 'https://oauth2.googleapis.com/token';
-const SCOPE = 'https://www.googleapis.com/auth/webmasters.readonly';
 
 export interface SearchRow {
   keys: string[];
@@ -73,68 +75,21 @@ export type SearchConsoleStats =
       pages: SearchRow[];
     };
 
-function b64url(bytes: Uint8Array): string {
-  let bin = '';
-  for (const b of bytes) bin += String.fromCharCode(b);
-  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+interface OauthEnv {
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
 }
 
-function pemToPkcs8(pem: string): Uint8Array {
-  const body = pem
-    .replace(/\\n/g, '\n')
-    .replace(/-----(BEGIN|END) PRIVATE KEY-----/g, '')
-    .replace(/\s+/g, '');
-  return Uint8Array.from(atob(body), (c) => c.charCodeAt(0));
-}
-
-async function signJwt(
-  clientEmail: string,
-  privateKeyPem: string,
-  now: Date,
-): Promise<string> {
-  const header = b64url(
-    new TextEncoder().encode(JSON.stringify({ alg: 'RS256', typ: 'JWT' })),
-  );
-  const iat = Math.floor(now.getTime() / 1000);
-  const claims = b64url(
-    new TextEncoder().encode(
-      JSON.stringify({
-        iss: clientEmail,
-        scope: SCOPE,
-        aud: TOKEN_URL,
-        iat,
-        exp: iat + 3600,
-      }),
-    ),
-  );
-  const signingInput = `${header}.${claims}`;
-  const key = await crypto.subtle.importKey(
-    'pkcs8',
-    pemToPkcs8(privateKeyPem).buffer as ArrayBuffer,
-    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
-    false,
-    ['sign'],
-  );
-  const sig = await crypto.subtle.sign(
-    'RSASSA-PKCS1-v1_5',
-    key,
-    new TextEncoder().encode(signingInput),
-  );
-  return `${signingInput}.${b64url(new Uint8Array(sig))}`;
-}
-
-async function accessToken(
-  clientEmail: string,
-  privateKeyPem: string,
-  now: Date,
-): Promise<string> {
-  const assertion = await signJwt(clientEmail, privateKeyPem, now);
+async function accessToken(env: OauthEnv): Promise<string> {
   const res = await fetch(TOKEN_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
-      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
-      assertion,
+      grant_type: 'refresh_token',
+      client_id: env.clientId,
+      client_secret: env.clientSecret,
+      refresh_token: env.refreshToken,
     }),
     cache: 'no-store',
   });
@@ -181,9 +136,12 @@ export async function readSearchConsoleStats(
   days: number,
   options: { now?: Date } = {},
 ): Promise<SearchConsoleStats> {
-  const clientEmail = process.env.GSC_CLIENT_EMAIL;
-  const privateKey = process.env.GSC_PRIVATE_KEY;
-  if (!clientEmail || !privateKey) return { status: 'unconfigured' };
+  const clientId = process.env.GSC_CLIENT_ID;
+  const clientSecret = process.env.GSC_CLIENT_SECRET;
+  const refreshToken = process.env.GSC_REFRESH_TOKEN;
+  if (!clientId || !clientSecret || !refreshToken) {
+    return { status: 'unconfigured' };
+  }
 
   const now = options.now ?? new Date();
   const dayMs = 24 * 60 * 60 * 1000;
@@ -195,7 +153,7 @@ export async function readSearchConsoleStats(
   };
 
   try {
-    const token = await accessToken(clientEmail, privateKey, now);
+    const token = await accessToken({ clientId, clientSecret, refreshToken });
     const [totalRows, queries, pages] = await Promise.all([
       searchAnalyticsQuery(token, { ...range }),
       searchAnalyticsQuery(token, {


### PR DESCRIPTION
Google's Secure-by-Default org policy (`iam.disableServiceAccountKeyCreation`) blocks downloading service-account keys on Maria's org, so the SEO panel's planned auth path could never be configured. This swaps it for an OAuth refresh-token flow — one consent grant from the property owner, no key file, nothing for the policy to block. Proven pattern from the Morgan site.

- `accessToken()` now does a refresh-token exchange; the WebCrypto RS256 JWT machinery (signJwt, pemToPkcs8, b64url) is deleted outright
- Env contract: `GSC_CLIENT_EMAIL`/`GSC_PRIVATE_KEY` → `GSC_CLIENT_ID`/`GSC_CLIENT_SECRET`/`GSC_REFRESH_TOKEN`; panel copy + CLAUDE.md updated
- Tests simplified: no node-environment pragma, no generated RSA key; added a null-position normalisation case

Gates green: typecheck, lint, 645 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)