### PR TITLE
feat: /logs — memorable alias for the argue-log admin page

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -33,6 +33,14 @@ const nextConfig: NextConfig = {
   async headers() {
     return [{ source: '/:path*', headers: SECURITY_HEADERS }];
   },
+  async redirects() {
+    return [
+      // Memorable admin door: /logs pairs with /stats. The redirect changes
+      // the address, not the lock — the target is Basic-auth gated in
+      // middleware.
+      { source: '/logs', destination: '/argue/log', permanent: false },
+    ];
+  },
 };
 
 const withMDX = createMDX({


### PR DESCRIPTION
bines.ai/logs → /argue/log (temporary redirect via next.config). The destination keeps its Basic-auth gate — this changes the address, not the lock. Pairs with /stats.

Gates green: typecheck, lint, 645 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)