### PR TITLE
feat(cron): weekly keep-warm ping for the Upstash rate-limit store

### DIFF
--- a/docs/keep-warm-ops.md
+++ b/docs/keep-warm-ops.md
@@ -1,0 +1,54 @@
+# Keep-warm operations runbook
+
+Internal docs for the `/api/keep-warm` cron. Scope: why it exists, the
+schedule, and how to run it by hand.
+
+Written for a single-operator context (Maria). British English throughout.
+Brevity over voice — this is a runbook, not copy.
+
+---
+
+## 1 · Why it exists
+
+The rate limiter on `/api/chat` is backed by a free-tier Vercel Marketplace
+Upstash store (`upstash-kv-yellow-pocket`). Upstash archives free databases
+that receive no traffic for a few weeks. The limiter only writes keys when
+someone actually uses the chat, so a quiet week leaves the store idle and
+eligible for archiving.
+
+If the store is archived the chat still works — the route fails open
+(`src/app/api/chat/route.ts`) — but it runs **unthrottled**, which removes the
+guard against someone hammering the Anthropic key. Keeping the store warm
+preserves that protection.
+
+## 2 · What it does
+
+`GET /api/keep-warm` calls `touchChatRedis()` (`src/lib/chat/rate-limit.ts`),
+which writes a single key `bines:chat:keepalive` with a 14-day TTL. One cheap
+write resets Upstash's inactivity clock. The key self-expires, so it never
+accumulates.
+
+Responses:
+
+- `200 { "warmed": true, "at": "<iso>" }` — pinged the store.
+- `200 { "warmed": false, "reason": "no-redis" }` — no Redis configured
+  (dev/CI); nothing to warm, not an error.
+- `401` — bad/missing bearer token.
+- `500 { "error": "misconfigured" }` — `CRON_SECRET` unset.
+
+## 3 · Schedule
+
+`vercel.json`: `0 5 * * 1` (Mondays 05:00 UTC, after the daily cleanup/sweep
+crons). Weekly leaves comfortable margin against the "few weeks" idle window.
+
+## 4 · Auth + manual run
+
+Same `Authorization: Bearer ${CRON_SECRET}` posture as the other crons
+(timing-safe compare). To run by hand:
+
+```bash
+curl -s https://bines.ai/api/keep-warm \
+  -H "Authorization: Bearer $CRON_SECRET"
+```
+
+`CRON_SECRET` lives in the Vercel project env (Production + Preview).

--- a/src/app/api/keep-warm/__tests__/route.test.ts
+++ b/src/app/api/keep-warm/__tests__/route.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/chat/rate-limit', () => ({
+  touchChatRedis: vi.fn(),
+}));
+
+import { touchChatRedis } from '@/lib/chat/rate-limit';
+import { GET } from '../route';
+
+const touchMock = vi.mocked(touchChatRedis);
+
+const ORIG_SECRET = process.env.CRON_SECRET;
+
+function makeRequest(auth?: string): Request {
+  const headers: Record<string, string> = {};
+  if (auth !== undefined) headers.authorization = auth;
+  return new Request('https://bines.ai/api/keep-warm', {
+    method: 'GET',
+    headers,
+  });
+}
+
+beforeEach(() => {
+  touchMock.mockReset();
+  process.env.CRON_SECRET = 'super-secret-value';
+});
+
+afterEach(() => {
+  if (ORIG_SECRET === undefined) delete process.env.CRON_SECRET;
+  else process.env.CRON_SECRET = ORIG_SECRET;
+});
+
+describe('GET /api/keep-warm — auth', () => {
+  it('returns 500 when CRON_SECRET is unset (misconfiguration)', async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(makeRequest('Bearer anything'));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('misconfigured');
+    expect(touchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when no Authorization header is present', async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    expect(touchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 on wrong scheme (e.g. Basic)', async () => {
+    const res = await GET(makeRequest('Basic super-secret-value'));
+    expect(res.status).toBe(401);
+    expect(touchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 on wrong bearer token', async () => {
+    const res = await GET(makeRequest('Bearer wrong-value-here-'));
+    expect(res.status).toBe(401);
+    expect(touchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 on equal-length-but-differing token (timing-safe)', async () => {
+    const almost = 'super-secret-valuX'.slice(0, 'super-secret-value'.length);
+    expect(almost).toHaveLength('super-secret-value'.length);
+    const res = await GET(makeRequest(`Bearer ${almost}`));
+    expect(res.status).toBe(401);
+    expect(touchMock).not.toHaveBeenCalled();
+  });
+
+  it('includes X-Governed-By header on 401', async () => {
+    const res = await GET(makeRequest());
+    expect(res.headers.get('x-governed-by')).toBe('bines.ai');
+  });
+});
+
+describe('GET /api/keep-warm — warming', () => {
+  it('pings Redis and reports the timestamp on success', async () => {
+    const ts = Date.UTC(2026, 5, 29, 5, 0, 0);
+    touchMock.mockResolvedValue(ts);
+    const res = await GET(makeRequest('Bearer super-secret-value'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ warmed: true, at: new Date(ts).toISOString() });
+    expect(touchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports warmed:false when no Redis is configured (dev/CI)', async () => {
+    touchMock.mockResolvedValue(null);
+    const res = await GET(makeRequest('Bearer super-secret-value'));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ warmed: false, reason: 'no-redis' });
+  });
+});

--- a/src/app/api/keep-warm/route.ts
+++ b/src/app/api/keep-warm/route.ts
@@ -1,0 +1,64 @@
+import { touchChatRedis } from '@/lib/chat/rate-limit';
+
+export const runtime = 'edge';
+
+const GOVERNED_BY_HEADER = { 'X-Governed-By': 'bines.ai' } as const;
+
+/**
+ * Weekly keep-alive ping for the Upstash rate-limit database.
+ *
+ * Schedule: `0 5 * * 1` UTC (Mondays, after the daily cleanup/sweep crons).
+ * Auth: `Authorization: Bearer ${CRON_SECRET}` via timing-safe compare —
+ * same posture as argue-log/cleanup and argue-judge/sweep.
+ *
+ * Why: the free-tier Vercel Marketplace Upstash store (`upstash-kv-yellow-
+ * pocket`) is archived after a few weeks with no traffic. The limiter only
+ * writes keys when someone uses /api/chat, so a low-traffic week leaves the
+ * store idle. This sends one cheap write to reset Upstash's inactivity clock
+ * and keep the abuse-protection limiter alive. See docs/keep-warm-ops.md.
+ */
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...GOVERNED_BY_HEADER },
+  });
+}
+
+/**
+ * Length-normalised, XOR-accumulator string comparison — no early-out on
+ * content. Length-dependent early return is an accepted leak (reveals token
+ * length, not content). No Node crypto.timingSafeEqual on edge runtime.
+ * Mirrors argue-log/cleanup; CRON_SECRET is ASCII hex (BMP charCodeAt exact).
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+export async function GET(req: Request): Promise<Response> {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    console.error('[keep-warm] CRON_SECRET unconfigured');
+    return jsonResponse(500, { error: 'misconfigured' });
+  }
+
+  const auth = req.headers.get('authorization') ?? '';
+  const prefix = 'Bearer ';
+  if (
+    !auth.startsWith(prefix) ||
+    !timingSafeEqual(auth.slice(prefix.length), secret)
+  ) {
+    return jsonResponse(401, { error: 'unauthorized' });
+  }
+
+  const at = await touchChatRedis();
+  if (at === null) {
+    // No Redis configured (dev/CI) — nothing to keep warm, not an error.
+    return jsonResponse(200, { warmed: false, reason: 'no-redis' });
+  }
+  return jsonResponse(200, { warmed: true, at: new Date(at).toISOString() });
+}

--- a/src/lib/chat/rate-limit.ts
+++ b/src/lib/chat/rate-limit.ts
@@ -68,6 +68,23 @@ export function getChatDailyRatelimit(): Ratelimit | null {
 }
 
 /**
+ * Touch the rate-limit Redis so Upstash doesn't archive the free-tier
+ * Marketplace database for inactivity. Writes a single self-expiring key
+ * (no key accumulation) and returns the timestamp written, or `null` when
+ * no Redis credentials are present (dev/CI) — same permissive posture as the
+ * limiter factories above. Called by the weekly /api/keep-warm cron.
+ */
+export async function touchChatRedis(): Promise<number | null> {
+  const redis = getRedisFromEnv();
+  if (!redis) return null;
+  const now = Date.now();
+  // 14-day TTL: the heartbeat self-expires well before the next weekly run,
+  // so the key never lingers and never accumulates.
+  await redis.set('bines:chat:keepalive', now, { ex: 1_209_600 });
+  return now;
+}
+
+/**
  * Reset cached instances. Test-only — production relies on module-level
  * memoisation across requests.
  */

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,8 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "crons": [
     { "path": "/api/argue-log/cleanup", "schedule": "30 3 * * *" },
-    { "path": "/api/argue-judge/sweep", "schedule": "30 4 * * *" }
+    { "path": "/api/argue-judge/sweep", "schedule": "30 4 * * *" },
+    { "path": "/api/keep-warm", "schedule": "0 5 * * 1" }
   ],
   "functions": {
     "src/app/api/argue-judge/sweep/route.ts": {


### PR DESCRIPTION
## Why

Upstash sent a free-tier inactivity notice (26 Jun 2026) for `upstash-kv-yellow-pocket` — the Vercel Marketplace store that backs the `/api/chat` rate limiter. Free databases get archived after a few weeks with no traffic, and the limiter only writes keys when someone uses the chat, so a quiet week leaves it idle.

If archived, the chat still works (the route fails open at `src/app/api/chat/route.ts`) but runs **unthrottled** — losing the guard against someone hammering the Anthropic key. This keeps the store alive with a cheap weekly heartbeat.

## What

- **`touchChatRedis()`** in `src/lib/chat/rate-limit.ts` — writes a single `bines:chat:keepalive` key with a 14-day TTL (self-expiring, never accumulates). Returns `null` when no Redis is configured (dev/CI), matching the limiter's permissive posture.
- **`GET /api/keep-warm`** — `CRON_SECRET` bearer auth via the same timing-safe compare as `argue-log/cleanup` and `argue-judge/sweep`.
- **`vercel.json` cron** — `0 5 * * 1` (Mondays 05:00 UTC, after the daily crons).
- **Tests** mirror the cleanup route's auth + behaviour coverage.
- **`docs/keep-warm-ops.md`** runbook.

## Notes

- Investigated the "legacy" `UPSTASH_REDIS_REST_*` env vars while here: they're **empty in both Production and Preview**, and `KV_REST_API_URL`/`KV_URL`/`REDIS_URL` all point at the single live store. There is no separate legacy database — just dead env-var entries + a now-unused fallback branch in `rate-limit.ts`. Left untouched here; can be cleaned up in a follow-up.

## Gates

`pnpm typecheck`, `pnpm lint`, `pnpm test` (653 passed), `pnpm build` — all green locally. Route registers as `ƒ /api/keep-warm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)